### PR TITLE
Add first-class /crawl workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   A visual playground for the <a href="https://developers.cloudflare.com/browser-rendering/rest-api/">Cloudflare Browser Rendering REST API</a>.<br/>
-  Take screenshots, generate PDFs, extract data — no code required.
+  Take screenshots, generate PDFs, extract data, and run full-site crawls — no code required.
 </p>
 
 <p align="center">
@@ -33,6 +33,7 @@ Cloudflare Browser Rendering gives you headless Chrome on Cloudflare's edge — 
 This playground gives you a GUI for the entire API. Pick an endpoint, enter a URL, hit send, see the result.
 
 - **Batch URLs** — test multiple sites in parallel, compare results side-by-side
+- **First-class crawl workflow** — start async `/crawl` jobs, poll progress, inspect records, paginate, and export results
 - **Live curl preview** — see the exact API call, copy it to your terminal
 - **Inline rendering** — images, PDFs, JSON trees, and markdown render directly in the response panel
 - **Cookie banner dismissal** — blocks 18+ consent providers for clean screenshots
@@ -73,8 +74,9 @@ Each API request spins up a new browser instance. Rate limits use a fixed per-se
 | REST API requests | **6**/min (1 every 10s) | **600**/min (10/sec) |
 | Concurrent browsers | 3 | 30 |
 | Browser time | 10 min/day | Unlimited |
+| `/crawl` jobs | 5/day, 100 pages/crawl | Account limits apply |
 
-Select your plan in settings — the playground adjusts request spacing automatically.
+Select your plan in settings — the playground adjusts request spacing automatically and validates free-plan crawl caps.
 
 ## Development
 
@@ -87,20 +89,32 @@ npm run deploy       # Build and deploy to Workers
 
 ### Architecture
 
-The app is data-driven. Endpoints are declared in `src/config/endpoints.ts` — each config specifies the API path, HTTP method, response type, and form fields. Adding a new endpoint is a single config entry; the form, curl preview, and response viewer derive from it automatically.
+The app has two UI paths:
+
+- Single-request endpoints stay data-driven through `src/config/endpoints.ts`, `src/lib/buildRequest.ts`, and `src/hooks/useBatchApiRequest.ts`.
+- `/crawl` is a dedicated async workflow with its own request builders, hook, and inspector UI because the API is job-based (`POST` create, `GET` poll/results, `DELETE` cancel).
 
 ```
 src/
-├── config/endpoints.ts    # Endpoint definitions (add new endpoints here)
+├── config/endpoints.ts    # Endpoint tab definitions
+├── config/crawl.ts        # Crawl-specific defaults and labels
 ├── components/
+│   ├── crawl/             # Crawl form + inspector-first async workspace
+│   ├── forms/             # Shared field primitives
 │   ├── viewers/           # Response viewers (HTML, Image, PDF, JSON, Markdown)
 │   ├── EndpointForm.tsx   # Dynamic form from endpoint config
 │   ├── CurlPreview.tsx    # Live curl command
 │   └── ResponsePanel.tsx  # Tabbed response display
 ├── hooks/
-│   └── useBatchApiRequest.ts  # Parallel multi-URL fetching
-├── lib/buildRequest.ts    # Request building + cookie dismissal
-└── types/api.ts           # TypeScript types
+│   ├── useBatchApiRequest.ts  # Parallel multi-URL fetching
+│   └── useCrawlJob.ts         # Async crawl job lifecycle
+├── lib/
+│   ├── buildRequest.ts    # Single-request request building + cookie dismissal
+│   ├── crawl.ts           # Crawl request/response normalization + export helpers
+│   └── rateLimits.ts      # Shared plan-aware rate limiting
+└── types/
+    ├── api.ts
+    └── crawl.ts
 ```
 
 ### Tech Stack

--- a/docs/cloudflare-browser-rendering-api.md
+++ b/docs/cloudflare-browser-rendering-api.md
@@ -7,6 +7,8 @@
 
 The Cloudflare Browser Rendering REST API provides a RESTful interface for common browser actions such as capturing screenshots, extracting HTML content, generating PDFs, and more.
 
+Most endpoints are single request/response operations. The `/crawl` endpoint is different: it creates an asynchronous crawl job, then requires follow-up `GET` requests to poll status and page through results, plus an optional `DELETE` request to cancel an in-flight job.
+
 **Base URL:** `https://api.cloudflare.com/client/v4/accounts/{accountId}/browser-rendering`
 
 **Authentication:** Bearer token via `Authorization: Bearer <apiToken>` header. Requires a custom API token with the `Browser Rendering - Edit` permission.
@@ -620,10 +622,98 @@ Extracts all hyperlinks from a rendered page.
 
 ---
 
+## 9. Crawl Endpoint (`/crawl`)
+
+**POST** `https://api.cloudflare.com/client/v4/accounts/{accountId}/browser-rendering/crawl`
+
+Starts an async crawl job for a starting URL and returns a job ID immediately.
+
+**Docs:** https://developers.cloudflare.com/browser-rendering/rest-api/crawl-endpoint/
+
+### Endpoint-Specific Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | Yes | - | Starting URL for the crawl job. |
+| `limit` | number | No | 10 | Maximum pages to crawl. Free plan users are capped at 100 pages/crawl. |
+| `depth` | number | No | 100000 | Maximum crawl depth from the starting URL. |
+| `source` | string | No | `"all"` | URL discovery source: `"all"`, `"sitemaps"`, or `"links"`. |
+| `formats` | string[] | No | `["html"]` | Output formats to store for each record: `"html"`, `"markdown"`, `"json"`. |
+| `render` | boolean | No | `true` | If `false`, fetches static HTML without browser execution. |
+| `jsonOptions` | object | No | - | JSON extraction configuration when `formats` includes `"json"`. |
+| `maxAge` | number | No | 86400 | Cache freshness in seconds before refetching. |
+| `modifiedSince` | number | No | - | Unix timestamp in seconds; only crawl newer content. |
+| `crawlPurposes` | string[] | No | `["search","ai-input","ai-train"]` | Declares content usage for Content Signals enforcement. |
+| `options.includeExternalLinks` | boolean | No | false | Follow external-domain links. |
+| `options.includeSubdomains` | boolean | No | false | Follow subdomain links. |
+| `options.includePatterns` | string[] | No | - | Wildcard URL patterns to include. |
+| `options.excludePatterns` | string[] | No | - | Wildcard URL patterns to exclude. |
+
+### Create Response
+
+```json
+{
+  "success": true,
+  "result": "c7f8s2d9-a8e7-4b6e-8e4d-3d4a1b2c3f4e"
+}
+```
+
+### Get Crawl Result
+
+**GET** `https://api.cloudflare.com/client/v4/accounts/{accountId}/browser-rendering/crawl/{jobId}`
+
+Use `limit`, `cursor`, `status`, and `cacheTTL` query parameters to keep status checks lightweight and page through records.
+
+Example response:
+
+```json
+{
+  "success": true,
+  "result": {
+    "id": "c7f8s2d9-a8e7-4b6e-8e4d-3d4a1b2c3f4e",
+    "status": "completed",
+    "browserSecondsUsed": 91.4,
+    "total": 50,
+    "finished": 50,
+    "skipped": 4,
+    "records": [
+      {
+        "url": "https://developers.cloudflare.com/workers/",
+        "status": "completed",
+        "markdown": "# Cloudflare Workers",
+        "metadata": {
+          "status": 200,
+          "title": "Cloudflare Workers · Cloudflare Docs",
+          "url": "https://developers.cloudflare.com/workers/"
+        }
+      }
+    ],
+    "cursor": "10"
+  }
+}
+```
+
+Record-level statuses are `queued`, `completed`, `disallowed`, `skipped`, `errored`, and `cancelled`.
+
+### Cancel Crawl Job
+
+**DELETE** `https://api.cloudflare.com/client/v4/accounts/{accountId}/browser-rendering/crawl/{jobId}`
+
+Cancels an in-progress crawl job and stops all queued URLs.
+
+### Workflow Notes
+
+- Crawl jobs can run for up to 7 days.
+- Completed crawl results are retained for 14 days by Cloudflare.
+- The endpoint respects `robots.txt`, `crawl-delay`, and Content Signals by default.
+- The crawler identifies itself as `CloudflareBrowserRenderingCrawler/1.0`.
+
+---
+
 ## Coverage: App vs. API
 
-All documented API parameters are implemented in the app's endpoint configuration (`src/config/endpoints.ts`).
+Single-request endpoints are implemented through the app's endpoint configuration (`src/config/endpoints.ts`).
 
-Every endpoint includes the full set of shared parameters (viewport, authentication, cookies, headers, request filtering, script/style injection, JavaScript toggle) plus all endpoint-specific parameters.
+The `/crawl` endpoint is implemented as a dedicated async workflow with its own form, polling, pagination, cancel, and export UI. The app currently exposes the core crawl fields plus browser-only controls that make sense for rendered crawls, rather than every single shared field from the one-shot endpoints.
 
-The only parameter not exposed as a form field is `screenshotOptions.encoding` (binary vs base64) — the app always uses binary encoding and renders images directly via blob URLs.
+The only parameter intentionally omitted from the one-shot endpoints remains `screenshotOptions.encoding` (binary vs base64) — the app always uses binary encoding and renders images directly via blob URLs.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', '.context/**', '.firecrawl/**', '.superpowers/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,27 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import type { EndpointId, InputMode, Settings } from './types/api'
+import { CRAWL_DEFAULTS } from './config/crawl'
 import { endpoints } from './config/endpoints'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useBatchApiRequest } from './hooks/useBatchApiRequest'
 import { buildCurlCommand } from './lib/buildRequest'
+import {
+  buildCrawlCreateCurlCommand,
+  buildCrawlDeleteCurlCommand,
+  buildCrawlGetCurlCommand,
+  validateCrawlFormValues,
+} from './lib/crawl'
+import { useCrawlJob } from './hooks/useCrawlJob'
 import { Header } from './components/Header'
 import { SettingsPanel } from './components/SettingsPanel'
 import { EndpointTabs } from './components/EndpointTabs'
 import { EndpointForm } from './components/EndpointForm'
 import { CurlPreview } from './components/CurlPreview'
 import { ResponsePanel } from './components/ResponsePanel'
+import { CrawlForm } from './components/crawl/CrawlForm'
+import { CrawlWorkspace } from './components/crawl/CrawlWorkspace'
+import type { CrawlCreateFormValues } from './types/crawl'
+import type { CrawlFieldErrors } from './lib/crawl'
 
 export default function App() {
   const [settings, setSettings] = useLocalStorage<Settings>('cf-br-settings', {
@@ -26,8 +38,14 @@ export default function App() {
   // Shared URL input — persists across endpoint tabs
   const [urlInput, setUrlInput] = useLocalStorage<string>('cf-br-urls', '')
   const [inputMode, setInputMode] = useLocalStorage<InputMode>('cf-br-input-mode', 'url')
+  const [crawlFormValues, setCrawlFormValues] = useLocalStorage<CrawlCreateFormValues>(
+    'cf-br-crawl-form-values',
+    CRAWL_DEFAULTS,
+  )
+  const [crawlErrors, setCrawlErrors] = useState<CrawlFieldErrors>({})
 
   const { entries, activeIndex, setActiveIndex, loading, execute, switchTo } = useBatchApiRequest()
+  const crawlJob = useCrawlJob(settings)
 
   const endpoint = endpoints.find((e) => e.id === activeEndpoint)!
   const currentValues = useMemo(
@@ -46,6 +64,26 @@ export default function App() {
       }))
     },
     [activeEndpoint, setFormValues],
+  )
+
+  const handleCrawlFieldChange = useCallback(
+    <K extends keyof CrawlCreateFormValues>(name: K, value: CrawlCreateFormValues[K]) => {
+      setCrawlErrors((prev) => {
+        const next = { ...prev }
+        delete next[name]
+        if (name === 'formats') {
+          delete next.formats
+          delete next.jsonPrompt
+          delete next.jsonResponseFormat
+        }
+        return next
+      })
+      setCrawlFormValues((prev) => ({
+        ...prev,
+        [name]: value,
+      }))
+    },
+    [setCrawlFormValues],
   )
 
   const handleEndpointChange = useCallback(
@@ -80,6 +118,26 @@ export default function App() {
     }
   }, [settingsReady, endpoint, settings, currentValues, urls, inputMode, execute])
 
+  const handleCrawlSubmit = useCallback(async () => {
+    if (!settingsReady) {
+      setShowSettings(true)
+      return
+    }
+
+    const errors = validateCrawlFormValues(crawlFormValues, settings.plan)
+    setCrawlErrors(errors)
+
+    if (Object.keys(errors).length > 0) {
+      return
+    }
+
+    if (crawlJob.job && !window.confirm('Start a new crawl and replace the current in-memory crawl job state?')) {
+      return
+    }
+
+    await crawlJob.startJob(crawlFormValues)
+  }, [crawlFormValues, crawlJob, settings.plan, settingsReady])
+
   // Cmd+Enter shortcut
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -97,10 +155,29 @@ export default function App() {
   const curlValues = inputMode === 'html'
     ? { ...currentValues, html: currentValues.html || '' }
     : { ...currentValues, url: activeUrl }
-  const curl = buildCurlCommand(endpoint, settings, curlValues)
+  const curl = activeEndpoint === 'crawl'
+    ? buildCrawlCreateCurlCommand(settings, crawlFormValues)
+    : buildCurlCommand(endpoint, settings, curlValues)
+  const pollCurl = buildCrawlGetCurlCommand(
+    settings,
+    crawlJob.job?.id || '<JOB_ID>',
+    { limit: 1 },
+  )
+  const cancelCurl = buildCrawlDeleteCurlCommand(settings, crawlJob.job?.id || '<JOB_ID>')
 
   // Active response for the selected tab
   const activeEntry = entries[activeIndex] || null
+  const crawlRecords = useMemo(
+    () => (crawlJob.resultsPage?.records || []).map((record, index) => ({
+      finalUrl: record.finalUrl,
+      httpStatus: record.httpStatus,
+      index,
+      status: record.status,
+      title: record.title,
+      url: record.url,
+    })),
+    [crawlJob.resultsPage],
+  )
 
   return (
     <div className="h-screen flex flex-col">
@@ -122,34 +199,84 @@ export default function App() {
       <div className="flex-1 flex flex-col lg:flex-row min-h-0 px-6 pb-6 gap-6">
         {/* Left: Form + Curl */}
         <div className="lg:w-[400px] shrink-0 flex flex-col gap-6 overflow-y-auto glass-panel rounded-xl shadow-2xl p-4 animate-slide-left">
-          <EndpointForm
-            endpoint={endpoint}
-            values={currentValues}
-            onChange={handleFieldChange}
-            onSubmit={handleSubmit}
-            loading={loading}
-            settingsReady={settingsReady}
-            submitRef={formSubmitRef}
-            urlInput={urlInput}
-            onUrlInputChange={setUrlInput}
-            inputMode={inputMode}
-            onInputModeChange={setInputMode}
-            urlCount={urls.length}
-          />
+          {activeEndpoint === 'crawl' ? (
+            <CrawlForm
+              errors={crawlErrors}
+              jobExists={Boolean(crawlJob.job)}
+              loading={crawlJob.creating}
+              onChange={handleCrawlFieldChange}
+              onSubmit={() => { void handleCrawlSubmit() }}
+              settingsReady={settingsReady}
+              submitRef={formSubmitRef}
+              values={crawlFormValues}
+            />
+          ) : (
+            <EndpointForm
+              endpoint={endpoint}
+              values={currentValues}
+              onChange={handleFieldChange}
+              onSubmit={handleSubmit}
+              loading={loading}
+              settingsReady={settingsReady}
+              submitRef={formSubmitRef}
+              urlInput={urlInput}
+              onUrlInputChange={setUrlInput}
+              inputMode={inputMode}
+              onInputModeChange={setInputMode}
+              urlCount={urls.length}
+            />
+          )}
           <CurlPreview curl={curl} />
         </div>
 
         {/* Right: Response */}
         <div className="flex-1 flex flex-col min-h-0 rounded-xl overflow-hidden shadow-2xl animate-fade-scale">
-          <ResponsePanel
-            entries={entries}
-            activeIndex={activeIndex}
-            onSelectIndex={setActiveIndex}
-            responseType={endpoint.responseType}
-            loading={loading}
-            response={activeEntry?.response || null}
-            entryLoading={activeEntry?.loading || false}
-          />
+          {activeEndpoint === 'crawl' ? (
+            <CrawlWorkspace
+              availableInspectorTabs={crawlJob.availableInspectorTabs}
+              cancelling={crawlJob.cancelling}
+              cancelCurl={cancelCurl}
+              exporting={crawlJob.exporting}
+              filteredRecordIndexes={crawlJob.filteredRecordIndexes}
+              filters={crawlJob.filters}
+              hasNextPage={crawlJob.hasNextPage}
+              hasPreviousPage={crawlJob.hasPreviousPage}
+              job={crawlJob.job}
+              jobError={crawlJob.jobError}
+              jobStartedAt={crawlJob.jobStartedAt}
+              lastRefreshedAt={crawlJob.lastRefreshedAt}
+              onCancel={crawlJob.cancelJob}
+              onExport={crawlJob.exportFilteredResults}
+              onNextPage={crawlJob.goToNextPage}
+              onPageSizeChange={crawlJob.setPageSize}
+              onPreviousPage={crawlJob.goToPreviousPage}
+              onRefresh={crawlJob.refreshAll}
+              onSearchChange={crawlJob.setSearch}
+              onSelectRecord={crawlJob.selectRecord}
+              onStatusChange={crawlJob.setStatusFilter}
+              pageIndex={crawlJob.pageIndex}
+              pollCurl={pollCurl}
+              polling={crawlJob.polling}
+              records={crawlRecords}
+              refreshingResults={crawlJob.refreshingResults}
+              refreshingSummary={crawlJob.refreshingSummary}
+              resultsError={crawlJob.resultsError}
+              selectedInspectorTab={crawlJob.selectedInspectorTab}
+              selectedRecord={crawlJob.selectedRecord}
+              selectedRecordIndex={crawlJob.selectedRecordIndex}
+              setInspectorTab={crawlJob.setInspectorTab}
+            />
+          ) : (
+            <ResponsePanel
+              entries={entries}
+              activeIndex={activeIndex}
+              onSelectIndex={setActiveIndex}
+              responseType={endpoint.responseType}
+              loading={loading}
+              response={activeEntry?.response || null}
+              entryLoading={activeEntry?.loading || false}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/EndpointForm.tsx
+++ b/src/components/EndpointForm.tsx
@@ -4,6 +4,8 @@ import { ChevronDown, ChevronRight, Play, Loader2, AlertTriangle, Globe, Code, C
 import type { EndpointConfig, FieldConfig, InputMode } from '../types/api'
 import { JsonSchemaBuilder } from './JsonSchemaBuilder'
 import { Toggle } from './Toggle'
+import { FieldControl } from './forms/FieldControl'
+import { FormField } from './forms/FormField'
 
 // Quick-start examples for the /json endpoint.
 // Ordered: broad/any-page → landing pages → content verticals → technical.
@@ -344,83 +346,6 @@ interface EndpointFormProps {
   urlCount: number
 }
 
-// Helper to get effective field value, falling back to defaultValue if unset
-function getEffectiveValue(field: FieldConfig, value: string): string {
-  // If value is set (even if empty string for text fields), use it
-  if (value !== undefined && value !== '') return value
-
-  // For boolean fields, if no value is set, use the defaultValue
-  if (field.type === 'boolean' && field.defaultValue !== undefined) {
-    return field.defaultValue ? 'true' : 'false'
-  }
-
-  return value || ''
-}
-
-function FieldInput({
-  field,
-  value,
-  onChange,
-  error,
-}: {
-  field: FieldConfig
-  value: string
-  onChange: (value: string) => void
-  error: boolean
-}) {
-  const effectiveValue = getEffectiveValue(field, value)
-  const border = error
-    ? 'border-red-500/60 focus:border-red-400'
-    : 'border-surface-300 focus:border-accent-500'
-
-  switch (field.type) {
-    case 'textarea':
-    case 'json':
-      return (
-        <textarea
-          value={effectiveValue}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={field.placeholder}
-          rows={field.type === 'json' ? 4 : 3}
-          className={`w-full px-3 py-2 bg-surface-200 border ${border} rounded-lg text-sm text-surface-900 placeholder:text-surface-500 focus:outline-none resize-y font-mono`}
-        />
-      )
-    case 'select':
-      return (
-        <select
-          value={effectiveValue}
-          onChange={(e) => onChange(e.target.value)}
-          className={`w-full px-3 py-2 bg-surface-200 border ${border} rounded-lg text-sm text-surface-900 focus:outline-none`}
-        >
-          <option value="">-- select --</option>
-          {field.options?.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      )
-    case 'boolean':
-      return (
-        <Toggle
-          checked={effectiveValue === 'true'}
-          onChange={(checked) => onChange(checked ? 'true' : 'false')}
-          label={effectiveValue === 'true' ? 'Yes' : 'No'}
-        />
-      )
-    default:
-      return (
-        <input
-          type={field.type === 'number' ? 'number' : 'text'}
-          value={effectiveValue}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={field.placeholder}
-          className={`w-full px-3 py-2 bg-surface-200 border ${border} rounded-lg text-sm text-surface-900 placeholder:text-surface-500 focus:outline-none`}
-        />
-      )
-  }
-}
-
 function getMissingRequired(
   endpoint: EndpointConfig,
   values: Record<string, string>,
@@ -748,21 +673,19 @@ export function EndpointForm({
           />
         ) : (
           <div key={field.name} className="pb-4 border-b border-surface-200 last:border-b-0 last:pb-0">
-            <label className="block text-xs font-medium text-surface-600 mb-1.5">
-              {field.label}
-              {field.required && <span className="text-accent-500 ml-1">*</span>}
-            </label>
-            <FieldInput
-              field={field}
-              value={values[field.name] || ''}
-              onChange={(v) => onChange(field.name, v)}
-              error={showError(field)}
-            />
-            {showError(field) ? (
-              <p className="text-xs text-red-400 mt-1.5">{field.label} is required</p>
-            ) : field.hint ? (
-              <p className="text-xs text-surface-500 mt-1.5 leading-relaxed">{field.hint}</p>
-            ) : null}
+            <FormField
+              label={field.label}
+              required={field.required}
+              error={showError(field) ? `${field.label} is required` : undefined}
+              hint={field.hint}
+            >
+              <FieldControl
+                field={field}
+                value={values[field.name] || ''}
+                onChange={(v) => onChange(field.name, v)}
+                error={showError(field)}
+              />
+            </FormField>
           </div>
         ),
       )}
@@ -785,21 +708,19 @@ export function EndpointForm({
             <div className="px-3 pt-2 pb-3 space-y-4">
               {fields.map((field, idx) => (
                 <div key={field.name} className={idx < fields.length - 1 ? 'pb-4 border-b border-surface-200' : ''}>
-                  <label className="block text-xs font-medium text-surface-600 mb-1.5">
-                    {field.label}
-                    {field.required && <span className="text-accent-500 ml-1">*</span>}
-                  </label>
-                  <FieldInput
-                    field={field}
-                    value={values[field.name] || ''}
-                    onChange={(v) => onChange(field.name, v)}
-                    error={showError(field)}
-                  />
-                  {showError(field) ? (
-                    <p className="text-xs text-red-400 mt-1.5">{field.label} is required</p>
-                  ) : field.hint ? (
-                    <p className="text-xs text-surface-500 mt-1.5 leading-relaxed">{field.hint}</p>
-                  ) : null}
+                  <FormField
+                    label={field.label}
+                    required={field.required}
+                    error={showError(field) ? `${field.label} is required` : undefined}
+                    hint={field.hint}
+                  >
+                    <FieldControl
+                      field={field}
+                      value={values[field.name] || ''}
+                      onChange={(v) => onChange(field.name, v)}
+                      error={showError(field)}
+                    />
+                  </FormField>
                 </div>
               ))}
             </div>

--- a/src/components/EndpointTabs.tsx
+++ b/src/components/EndpointTabs.tsx
@@ -17,6 +17,7 @@ const docsUrlMap: Record<string, string> = {
   snapshot: '/browser-rendering/rest-api/snapshot/',
   scrape: '/browser-rendering/rest-api/scrape-endpoint/',
   links: '/browser-rendering/rest-api/links-endpoint/',
+  crawl: '/browser-rendering/rest-api/crawl-endpoint/',
 }
 
 export function EndpointTabs({ endpoints, activeId, onSelect }: EndpointTabsProps) {

--- a/src/components/ResponsePanel.tsx
+++ b/src/components/ResponsePanel.tsx
@@ -232,6 +232,10 @@ function ResponseViewer({ response, responseType }: { response: ApiResponse; res
       return <MarkdownViewer data={data} />
     case 'snapshot':
       return <SnapshotViewer screenshot={null} html={null} />
+    case 'crawl':
+      return (
+        <pre className="p-4 text-sm text-surface-700 whitespace-pre-wrap">{data}</pre>
+      )
     default:
       return (
         <pre className="p-4 text-sm text-surface-700 whitespace-pre-wrap">{data}</pre>
@@ -300,6 +304,7 @@ const RESPONSE_TYPE_EXT: Record<ResponseType, string> = {
   json: 'json',
   markdown: 'md',
   snapshot: 'json',
+  crawl: 'json',
 }
 
 const RESPONSE_TYPE_LABEL: Record<ResponseType, string> = {
@@ -309,6 +314,7 @@ const RESPONSE_TYPE_LABEL: Record<ResponseType, string> = {
   json: 'data',
   markdown: 'markdown',
   snapshot: 'snapshot',
+  crawl: 'crawl',
 }
 
 function buildDownloadName(url: string, responseType: ResponseType): string {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -163,6 +163,7 @@ export function SettingsPanel({ settings, onChange, onClose }: SettingsPanelProp
                 <div>• 6 requests/min (1 every 10s)</div>
                 <div>• 3 concurrent browsers</div>
                 <div>• 10 min browser time/day</div>
+                <div>• Crawl: 5 jobs/day, 100 pages/crawl</div>
               </div>
             </button>
             <button
@@ -184,6 +185,7 @@ export function SettingsPanel({ settings, onChange, onClose }: SettingsPanelProp
                 <div>• 600 requests/min (10/sec)</div>
                 <div>• 30 concurrent browsers</div>
                 <div>• Unlimited browser time</div>
+                <div>• Crawl caps scale with account limits</div>
               </div>
             </button>
           </div>

--- a/src/components/crawl/CrawlEmptyState.tsx
+++ b/src/components/crawl/CrawlEmptyState.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+
+interface CrawlEmptyStateProps {
+  title: string
+  description: string
+  action?: ReactNode
+}
+
+export function CrawlEmptyState({
+  title,
+  description,
+  action,
+}: CrawlEmptyStateProps) {
+  return (
+    <div className="h-full flex items-center justify-center p-6">
+      <div className="max-w-md text-center glass-panel rounded-2xl border border-surface-300 px-6 py-8">
+        <h3 className="text-base font-medium text-surface-900">{title}</h3>
+        <p className="mt-2 text-sm text-surface-600 leading-relaxed">{description}</p>
+        {action ? <div className="mt-4">{action}</div> : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/crawl/CrawlForm.tsx
+++ b/src/components/crawl/CrawlForm.tsx
@@ -1,0 +1,549 @@
+import type { RefObject } from 'react'
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Loader2, Play } from 'lucide-react'
+import {
+  CRAWL_FORMAT_OPTIONS,
+  CRAWL_PURPOSE_OPTIONS,
+  CRAWL_SOURCE_OPTIONS,
+} from '../../config/crawl'
+import type { CrawlFieldErrors } from '../../lib/crawl'
+import type { FieldConfig } from '../../types/api'
+import type { CrawlCreateFormValues, CrawlFormat, CrawlPurpose } from '../../types/crawl'
+import { JsonSchemaBuilder } from '../JsonSchemaBuilder'
+import { Toggle } from '../Toggle'
+import { FieldControl } from '../forms/FieldControl'
+import { FormField } from '../forms/FormField'
+
+const LIMIT_FIELD: FieldConfig = {
+  hint: 'Workers Free plan: maximum 100 pages per crawl.',
+  label: 'Page limit',
+  name: 'limit',
+  placeholder: '25',
+  type: 'number',
+}
+
+const DEPTH_FIELD: FieldConfig = {
+  hint: 'Maximum link depth from the starting URL.',
+  label: 'Depth',
+  name: 'depth',
+  placeholder: '2',
+  type: 'number',
+}
+
+const SOURCE_FIELD: FieldConfig = {
+  hint: 'Choose how the crawler discovers more URLs.',
+  label: 'Discovery source',
+  name: 'source',
+  options: CRAWL_SOURCE_OPTIONS.map((option) => ({ label: option.label, value: option.value })),
+  type: 'select',
+}
+
+const MAX_AGE_FIELD: FieldConfig = {
+  hint: 'Maximum cache age in seconds before the crawler refetches content.',
+  label: 'Max age (seconds)',
+  name: 'maxAge',
+  placeholder: '86400',
+  type: 'number',
+}
+
+const MODIFIED_SINCE_FIELD: FieldConfig = {
+  hint: 'Unix timestamp in seconds to skip older pages.',
+  label: 'Modified since',
+  name: 'modifiedSince',
+  placeholder: '1704067200',
+  type: 'number',
+}
+
+const GOTO_WAIT_UNTIL_FIELD: FieldConfig = {
+  hint: 'Navigation completion signal for rendered crawls.',
+  label: 'Wait until',
+  name: 'gotoWaitUntil',
+  options: [
+    { label: 'load', value: 'load' },
+    { label: 'domcontentloaded', value: 'domcontentloaded' },
+    { label: 'networkidle0', value: 'networkidle0' },
+    { label: 'networkidle2', value: 'networkidle2' },
+  ],
+  type: 'select',
+}
+
+const GOTO_TIMEOUT_FIELD: FieldConfig = {
+  hint: 'Navigation timeout in milliseconds.',
+  label: 'Goto timeout (ms)',
+  name: 'gotoTimeout',
+  placeholder: '30000',
+  type: 'number',
+}
+
+const WAIT_FOR_SELECTOR_FIELD: FieldConfig = {
+  hint: 'Wait for a selector before capturing the rendered page.',
+  label: 'Wait for selector',
+  name: 'waitForSelector',
+  placeholder: '#content',
+  type: 'text',
+}
+
+const INCLUDE_PATTERNS_FIELD: FieldConfig = {
+  hint: 'JSON array of wildcard URL patterns to include.',
+  label: 'Include patterns',
+  name: 'includePatterns',
+  placeholder: '["https://example.com/docs/**"]',
+  type: 'json',
+}
+
+const EXCLUDE_PATTERNS_FIELD: FieldConfig = {
+  hint: 'JSON array of wildcard URL patterns to exclude.',
+  label: 'Exclude patterns',
+  name: 'excludePatterns',
+  placeholder: '["https://example.com/docs/archive/**"]',
+  type: 'json',
+}
+
+const ADD_SCRIPT_TAG_FIELD: FieldConfig = {
+  hint: 'JSON array of scripts to inject before capture.',
+  label: 'Inject scripts',
+  name: 'addScriptTag',
+  placeholder: '[{"content":"console.log(1)"}]',
+  type: 'json',
+}
+
+const ADD_STYLE_TAG_FIELD: FieldConfig = {
+  hint: 'JSON array of styles to inject before capture.',
+  label: 'Inject styles',
+  name: 'addStyleTag',
+  placeholder: '[{"content":"body { background: red; }"}]',
+  type: 'json',
+}
+
+const REJECT_REQUEST_PATTERN_FIELD: FieldConfig = {
+  hint: 'JSON array of regex strings for blocked requests.',
+  label: 'Block request URL patterns',
+  name: 'rejectRequestPattern',
+  placeholder: '["ads\\\\.example\\\\.com"]',
+  type: 'json',
+}
+
+const ALLOW_REQUEST_PATTERN_FIELD: FieldConfig = {
+  hint: 'JSON array of regex strings for allowed requests only.',
+  label: 'Allow request URL patterns',
+  name: 'allowRequestPattern',
+  placeholder: '["example\\\\.com"]',
+  type: 'json',
+}
+
+const REJECT_RESOURCE_TYPES_FIELD: FieldConfig = {
+  hint: 'JSON array of resource types to block.',
+  label: 'Block resource types',
+  name: 'rejectResourceTypes',
+  placeholder: '["image","font"]',
+  type: 'json',
+}
+
+const ALLOW_RESOURCE_TYPES_FIELD: FieldConfig = {
+  hint: 'JSON array of resource types to allow.',
+  label: 'Allow resource types',
+  name: 'allowResourceTypes',
+  placeholder: '["document","script"]',
+  type: 'json',
+}
+
+const JSON_PROMPT_FIELD: FieldConfig = {
+  hint: 'Describe the structured data to extract from each crawled page.',
+  label: 'JSON prompt',
+  name: 'jsonPrompt',
+  placeholder: 'Extract product name, price, and availability',
+  type: 'textarea',
+}
+
+const JSON_CUSTOM_AI_FIELD: FieldConfig = {
+  hint: 'JSON array of custom models with authorization headers.',
+  label: 'Custom AI models',
+  name: 'jsonCustomAi',
+  placeholder: '[{"model":"openai/gpt-4o-mini","authorization":"Bearer ..."}]',
+  type: 'json',
+}
+
+function ChoiceChip({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1.5 rounded-full border text-xs transition-colors ${
+        active
+          ? 'border-accent-500 bg-accent-500/15 text-accent-500'
+          : 'border-surface-300 text-surface-600 hover:text-surface-800 hover:bg-surface-200'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+function ConfigField({
+  error,
+  field,
+  onChange,
+  value,
+}: {
+  error?: string
+  field: FieldConfig
+  onChange: (value: string) => void
+  value: string
+}) {
+  return (
+    <FormField error={error} hint={field.hint} label={field.label}>
+      <FieldControl
+        error={Boolean(error)}
+        field={field}
+        onChange={onChange}
+        value={value}
+      />
+    </FormField>
+  )
+}
+
+interface CrawlFormProps {
+  errors: CrawlFieldErrors
+  jobExists: boolean
+  loading: boolean
+  onChange: <K extends keyof CrawlCreateFormValues>(field: K, value: CrawlCreateFormValues[K]) => void
+  onSubmit: () => void
+  settingsReady: boolean
+  submitRef?: RefObject<HTMLButtonElement | null>
+  values: CrawlCreateFormValues
+}
+
+export function CrawlForm({
+  errors,
+  jobExists,
+  loading,
+  onChange,
+  onSubmit,
+  settingsReady,
+  submitRef,
+  values,
+}: CrawlFormProps) {
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set())
+
+  const toggleSection = (name: string) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  const toggleFormat = (format: CrawlFormat) => {
+    const next = values.formats.includes(format)
+      ? values.formats.filter((value) => value !== format)
+      : [...values.formats, format]
+    onChange('formats', next)
+  }
+
+  const togglePurpose = (purpose: CrawlPurpose) => {
+    const next = values.crawlPurposes.includes(purpose)
+      ? values.crawlPurposes.filter((value) => value !== purpose)
+      : [...values.crawlPurposes, purpose]
+    onChange('crawlPurposes', next)
+  }
+
+  const submitLabel = loading
+    ? 'Starting crawl…'
+    : jobExists
+      ? 'Start New Crawl'
+      : 'Start Crawl'
+
+  const renderAdvancedSections = values.render
+
+  return (
+    <div className="space-y-4">
+      <div className="pb-3 border-b border-surface-300">
+        <h2 className="text-base font-medium text-accent-primary mb-1">/crawl</h2>
+        <p className="text-sm text-surface-700 leading-relaxed">
+          Crawl an entire site as an async Browser Rendering job, then inspect records page by page without leaving the playground.
+        </p>
+      </div>
+
+      <FormField
+        error={errors.url}
+        hint="Single starting URL only. Crawl jobs run asynchronously and keep their state in this session."
+        label="Starting URL"
+        required
+      >
+        <input
+          type="text"
+          value={values.url}
+          onChange={(event) => onChange('url', event.target.value)}
+          placeholder="https://developers.cloudflare.com/workers/"
+          className={`w-full px-3 py-2 bg-surface-200 border rounded-lg text-sm text-surface-900 placeholder:text-surface-500 focus:outline-none ${
+            errors.url ? 'border-red-500/60 focus:border-red-400' : 'border-surface-300 focus:border-accent-500'
+          }`}
+        />
+      </FormField>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <ConfigField
+          error={errors.limit}
+          field={LIMIT_FIELD}
+          onChange={(value) => onChange('limit', value)}
+          value={values.limit}
+        />
+        <ConfigField
+          error={errors.depth}
+          field={DEPTH_FIELD}
+          onChange={(value) => onChange('depth', value)}
+          value={values.depth}
+        />
+      </div>
+
+      <ConfigField
+        error={errors.source}
+        field={SOURCE_FIELD}
+        onChange={(value) => onChange('source', value as CrawlCreateFormValues['source'])}
+        value={values.source}
+      />
+
+      <FormField
+        error={errors.formats}
+        hint="Markdown is the best default for inspection. JSON uses Workers AI or your custom model settings."
+        label="Output formats"
+        required
+      >
+        <div className="flex flex-wrap gap-2">
+          {CRAWL_FORMAT_OPTIONS.map((option) => (
+            <ChoiceChip
+              key={option.value}
+              active={values.formats.includes(option.value)}
+              label={option.label}
+              onClick={() => toggleFormat(option.value)}
+            />
+          ))}
+        </div>
+      </FormField>
+
+      <FormField
+        hint="Declare the intended use of crawled content. `search` is the safest default for Content Signals compatibility."
+        label="Crawl purposes"
+      >
+        <div className="flex flex-wrap gap-2">
+          {CRAWL_PURPOSE_OPTIONS.map((option) => (
+            <ChoiceChip
+              key={option.value}
+              active={values.crawlPurposes.includes(option.value)}
+              label={option.label}
+              onClick={() => togglePurpose(option.value)}
+            />
+          ))}
+        </div>
+      </FormField>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <FormField
+          hint="Disable browser rendering for faster static HTML fetches."
+          label="Render pages in a browser"
+        >
+          <Toggle
+            checked={values.render}
+            label={values.render ? 'On' : 'Off'}
+            onChange={(checked) => onChange('render', checked)}
+          />
+        </FormField>
+        <FormField
+          hint="Follow links outside the starting domain."
+          label="Include external links"
+        >
+          <Toggle
+            checked={values.includeExternalLinks}
+            label={values.includeExternalLinks ? 'On' : 'Off'}
+            onChange={(checked) => onChange('includeExternalLinks', checked)}
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <FormField
+          hint="Follow links on subdomains of the starting URL."
+          label="Include subdomains"
+        >
+          <Toggle
+            checked={values.includeSubdomains}
+            label={values.includeSubdomains ? 'On' : 'Off'}
+            onChange={(checked) => onChange('includeSubdomains', checked)}
+          />
+        </FormField>
+        {values.render && (
+          <FormField
+            hint="Blocks common consent managers before the crawl captures rendered content."
+            label="Dismiss cookie banners"
+          >
+            <Toggle
+              checked={values.dismissCookies}
+              label={values.dismissCookies ? 'On' : 'Off'}
+              onChange={(checked) => onChange('dismissCookies', checked)}
+            />
+          </FormField>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <ConfigField
+          error={errors.maxAge}
+          field={MAX_AGE_FIELD}
+          onChange={(value) => onChange('maxAge', value)}
+          value={values.maxAge}
+        />
+        <ConfigField
+          error={errors.modifiedSince}
+          field={MODIFIED_SINCE_FIELD}
+          onChange={(value) => onChange('modifiedSince', value)}
+          value={values.modifiedSince}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-3">
+        <ConfigField
+          error={errors.includePatterns}
+          field={INCLUDE_PATTERNS_FIELD}
+          onChange={(value) => onChange('includePatterns', value)}
+          value={values.includePatterns}
+        />
+        <ConfigField
+          error={errors.excludePatterns}
+          field={EXCLUDE_PATTERNS_FIELD}
+          onChange={(value) => onChange('excludePatterns', value)}
+          value={values.excludePatterns}
+        />
+      </div>
+
+      {values.formats.includes('json') && (
+        <div className="border border-surface-300 rounded-lg overflow-hidden">
+          <div className="px-3 py-2 text-xs text-surface-600 bg-surface-100 border-b border-surface-300">
+            JSON extraction
+          </div>
+          <div className="px-3 py-3 space-y-4">
+            <ConfigField
+              error={errors.jsonPrompt}
+              field={JSON_PROMPT_FIELD}
+              onChange={(value) => onChange('jsonPrompt', value)}
+              value={values.jsonPrompt}
+            />
+            <div>
+              <JsonSchemaBuilder
+                value={values.jsonResponseFormat}
+                onChange={(value) => onChange('jsonResponseFormat', value)}
+              />
+              {errors.jsonResponseFormat && (
+                <p className="text-xs text-red-400 mt-1.5">{errors.jsonResponseFormat}</p>
+              )}
+            </div>
+            <ConfigField
+              error={errors.jsonCustomAi}
+              field={JSON_CUSTOM_AI_FIELD}
+              onChange={(value) => onChange('jsonCustomAi', value)}
+              value={values.jsonCustomAi}
+            />
+          </div>
+        </div>
+      )}
+
+      {renderAdvancedSections && (
+        <>
+          {[
+            {
+              fields: [
+                { key: 'gotoWaitUntil', field: GOTO_WAIT_UNTIL_FIELD },
+                { key: 'gotoTimeout', field: GOTO_TIMEOUT_FIELD },
+                { key: 'waitForSelector', field: WAIT_FOR_SELECTOR_FIELD },
+              ] as const,
+              name: 'Navigation Controls',
+            },
+            {
+              fields: [
+                { key: 'rejectRequestPattern', field: REJECT_REQUEST_PATTERN_FIELD },
+                { key: 'allowRequestPattern', field: ALLOW_REQUEST_PATTERN_FIELD },
+                { key: 'rejectResourceTypes', field: REJECT_RESOURCE_TYPES_FIELD },
+                { key: 'allowResourceTypes', field: ALLOW_RESOURCE_TYPES_FIELD },
+              ] as const,
+              name: 'Request Filtering',
+            },
+            {
+              fields: [
+                { key: 'addScriptTag', field: ADD_SCRIPT_TAG_FIELD },
+                { key: 'addStyleTag', field: ADD_STYLE_TAG_FIELD },
+              ] as const,
+              name: 'Injection',
+            },
+          ].map((section) => (
+            <div key={section.name} className="border border-surface-300 rounded-lg overflow-hidden">
+              <button
+                type="button"
+                onClick={() => toggleSection(section.name)}
+                className="w-full flex items-center gap-2 px-3 py-2 text-xs text-surface-600 hover:bg-surface-200 transition-colors"
+              >
+                {expandedSections.has(section.name)
+                  ? <ChevronDown className="w-3.5 h-3.5" />
+                  : <ChevronRight className="w-3.5 h-3.5" />}
+                {section.name}
+              </button>
+              {expandedSections.has(section.name) && (
+                <div className="px-3 py-3 space-y-4 border-t border-surface-300">
+                  {section.name === 'Navigation Controls' && (
+                    <FormField
+                      hint="Disable JavaScript execution for rendered crawls."
+                      label="JavaScript enabled"
+                    >
+                      <Toggle
+                        checked={values.setJavaScriptEnabled}
+                        label={values.setJavaScriptEnabled ? 'On' : 'Off'}
+                        onChange={(checked) => onChange('setJavaScriptEnabled', checked)}
+                      />
+                    </FormField>
+                  )}
+
+                  {section.fields.map(({ field, key }) => (
+                    <ConfigField
+                      key={field.name}
+                      error={errors[key]}
+                      field={field}
+                      onChange={(value) => onChange(key, value as CrawlCreateFormValues[typeof key])}
+                      value={String(values[key] || '')}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </>
+      )}
+
+      {!settingsReady && (
+        <div className="flex items-start gap-2.5 px-3 py-2.5 bg-accent-500/10 border border-accent-500/20 rounded-lg">
+          <p className="text-xs text-surface-700">
+            Configure your Account ID and API Token in settings before starting a crawl.
+          </p>
+        </div>
+      )}
+
+      <button
+        ref={submitRef}
+        type="button"
+        onClick={onSubmit}
+        disabled={loading || !settingsReady}
+        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-accent-500 hover:bg-accent-400 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg text-sm font-medium transition-colors"
+      >
+        {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+        {submitLabel}
+        {!loading && <kbd className="ml-2 text-xs opacity-60 hidden sm:inline">Cmd+Enter</kbd>}
+      </button>
+    </div>
+  )
+}

--- a/src/components/crawl/CrawlJobSummary.tsx
+++ b/src/components/crawl/CrawlJobSummary.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Check, Copy, Download, Loader2, RefreshCw, Square, Database } from 'lucide-react'
+import { CRAWL_JOB_STATUS_LABELS } from '../../config/crawl'
+import type { CrawlJobSummary } from '../../types/crawl'
+
+interface CrawlJobSummaryProps {
+  cancelling: boolean
+  cancelCurl: string
+  exporting: boolean
+  job: CrawlJobSummary
+  jobError: string | null
+  jobStartedAt: number | null
+  lastRefreshedAt: number | null
+  onCancel: () => Promise<void> | void
+  onExport: () => Promise<void> | void
+  onRefresh: () => Promise<void> | void
+  onViewRawJob: () => void
+  pollCurl: string
+  polling: boolean
+  refreshingSummary: boolean
+}
+
+function ActionButton({
+  disabled = false,
+  onClick,
+  children,
+}: {
+  children: ReactNode
+  disabled?: boolean
+  onClick: () => Promise<void> | void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => void onClick()}
+      disabled={disabled}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-surface-300 text-xs text-surface-700 hover:bg-surface-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+    >
+      {children}
+    </button>
+  )
+}
+
+export function CrawlJobSummary({
+  cancelling,
+  cancelCurl,
+  exporting,
+  job,
+  jobError,
+  jobStartedAt,
+  lastRefreshedAt,
+  onCancel,
+  onExport,
+  onRefresh,
+  onViewRawJob,
+  pollCurl,
+  polling,
+  refreshingSummary,
+}: CrawlJobSummaryProps) {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null)
+  const [now, setNow] = useState(() => Date.now())
+
+  const handleCopy = async (key: string, text: string) => {
+    await navigator.clipboard.writeText(text)
+    setCopiedKey(key)
+    window.setTimeout(() => setCopiedKey((current) => current === key ? null : current), 1500)
+  }
+
+  const isRunning = job.status === 'running'
+  const canExport = !isRunning
+  const loadingSummary = polling || refreshingSummary
+  const elapsedMs = jobStartedAt ? Math.max(0, now - jobStartedAt) : 0
+  const elapsedLabel = `${String(Math.floor(elapsedMs / 60000)).padStart(2, '0')}:${String(Math.floor((elapsedMs % 60000) / 1000)).padStart(2, '0')}`
+
+  useEffect(() => {
+    if (!jobStartedAt || !isRunning) return
+
+    const timer = window.setInterval(() => {
+      setNow(Date.now())
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [isRunning, jobStartedAt])
+
+  return (
+    <div className="glass-panel rounded-xl border border-surface-300 overflow-hidden">
+      <div className="px-4 py-3 border-b border-surface-300 bg-surface-100">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm text-surface-900 font-medium">Job {job.id}</p>
+            <p className="text-xs text-surface-500 mt-1">
+              Status: {CRAWL_JOB_STATUS_LABELS[job.status]}
+              {jobStartedAt ? ` · Elapsed ${elapsedLabel}` : ''}
+              {lastRefreshedAt ? ` · Refreshed ${new Date(lastRefreshedAt).toLocaleTimeString()}` : ''}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <ActionButton onClick={onRefresh} disabled={loadingSummary}>
+              {loadingSummary ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
+              Refresh
+            </ActionButton>
+            <ActionButton onClick={onCancel} disabled={!isRunning || cancelling}>
+              {cancelling ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Square className="w-3.5 h-3.5" />}
+              Cancel
+            </ActionButton>
+            <ActionButton onClick={onViewRawJob}>
+              <Database className="w-3.5 h-3.5" />
+              View raw job JSON
+            </ActionButton>
+            <ActionButton onClick={() => handleCopy('poll', pollCurl)}>
+              {copiedKey === 'poll' ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+              Copy poll curl
+            </ActionButton>
+            <ActionButton onClick={() => handleCopy('cancel', cancelCurl)}>
+              {copiedKey === 'cancel' ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+              Copy cancel curl
+            </ActionButton>
+            <ActionButton onClick={onExport} disabled={!canExport || exporting}>
+              {exporting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Download className="w-3.5 h-3.5" />}
+              Export ZIP
+            </ActionButton>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-px bg-surface-300">
+        <div className="bg-surface-100 px-4 py-3">
+          <p className="text-[11px] uppercase tracking-wide text-surface-500">Job status</p>
+          <p className="mt-1 text-sm text-surface-900">{CRAWL_JOB_STATUS_LABELS[job.status]}</p>
+        </div>
+        <div className="bg-surface-100 px-4 py-3">
+          <p className="text-[11px] uppercase tracking-wide text-surface-500">Finished</p>
+          <p className="mt-1 text-sm text-surface-900">{job.finished} / {job.total}</p>
+        </div>
+        <div className="bg-surface-100 px-4 py-3">
+          <p className="text-[11px] uppercase tracking-wide text-surface-500">Skipped</p>
+          <p className="mt-1 text-sm text-surface-900">{job.skipped}</p>
+        </div>
+        <div className="bg-surface-100 px-4 py-3">
+          <p className="text-[11px] uppercase tracking-wide text-surface-500">Browser seconds</p>
+          <p className="mt-1 text-sm text-surface-900">{job.browserSecondsUsed.toFixed(1)}</p>
+        </div>
+        <div className="bg-surface-100 px-4 py-3">
+          <p className="text-[11px] uppercase tracking-wide text-surface-500">Cursor</p>
+          <p className="mt-1 text-sm text-surface-900">{job.cursor ?? 'None'}</p>
+        </div>
+      </div>
+
+      {(jobError || job.status === 'cancelled_due_to_limits') && (
+        <div className="border-t border-surface-300 px-4 py-3 bg-red-500/8">
+          <p className="text-sm text-red-300">
+            {jobError || 'Cloudflare cancelled this crawl because the account hit its crawl or Browser Rendering limits.'}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/crawl/CrawlRecordInspector.tsx
+++ b/src/components/crawl/CrawlRecordInspector.tsx
@@ -1,0 +1,112 @@
+import { ExternalLink } from 'lucide-react'
+import { CRAWL_RECORD_STATUS_LABELS } from '../../config/crawl'
+import type { CrawlInspectorTab, CrawlRecord } from '../../types/crawl'
+import { HtmlViewer } from '../viewers/HtmlViewer'
+import { JsonViewer } from '../viewers/JsonViewer'
+import { MarkdownViewer } from '../viewers/MarkdownViewer'
+import { CrawlEmptyState } from './CrawlEmptyState'
+
+interface CrawlRecordInspectorProps {
+  activeTab: CrawlInspectorTab
+  availableTabs: CrawlInspectorTab[]
+  onTabChange: (tab: CrawlInspectorTab) => void
+  record: CrawlRecord | null
+}
+
+const TAB_LABELS: Record<CrawlInspectorTab, string> = {
+  markdown: 'Markdown',
+  html: 'HTML',
+  json: 'JSON',
+  raw: 'Raw',
+}
+
+function RecordViewer({
+  activeTab,
+  record,
+}: {
+  activeTab: CrawlInspectorTab
+  record: CrawlRecord
+}) {
+  switch (activeTab) {
+    case 'markdown':
+      return record.markdown ? <MarkdownViewer data={record.markdown} /> : null
+    case 'html':
+      return record.html ? <HtmlViewer data={record.html} /> : null
+    case 'json':
+      return record.json ? <JsonViewer data={JSON.stringify(record.json, null, 2)} /> : null
+    case 'raw':
+      return <JsonViewer data={JSON.stringify(record.raw, null, 2)} />
+  }
+}
+
+export function CrawlRecordInspector({
+  activeTab,
+  availableTabs,
+  onTabChange,
+  record,
+}: CrawlRecordInspectorProps) {
+  if (!record) {
+    return (
+      <CrawlEmptyState
+        title="No record selected"
+        description="Select a record from the list to inspect its payload, markdown, HTML, or raw envelope."
+      />
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col glass-panel rounded-xl border border-surface-300 overflow-hidden">
+      <div className="border-b border-surface-300 px-4 py-3 bg-surface-100">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center rounded-full border border-surface-300 px-2 py-0.5 text-[11px] text-surface-700">
+            {CRAWL_RECORD_STATUS_LABELS[record.status]}
+          </span>
+          {record.httpStatus !== undefined && (
+            <span className="inline-flex items-center rounded-full border border-surface-300 px-2 py-0.5 text-[11px] text-surface-700">
+              HTTP {record.httpStatus}
+            </span>
+          )}
+          {record.title && (
+            <span className="text-xs text-surface-500 truncate">{record.title}</span>
+          )}
+        </div>
+        <p className="mt-2 text-sm text-surface-900 break-all">{record.url}</p>
+        {record.finalUrl && record.finalUrl !== record.url && (
+          <p className="mt-1 text-xs text-surface-500 break-all">
+            Final URL:{' '}
+            <a
+              href={record.finalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-500 hover:text-accent-400 inline-flex items-center gap-1"
+            >
+              {record.finalUrl}
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 border-b border-surface-300 px-3 py-2 bg-surface-100">
+        {availableTabs.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => onTabChange(tab)}
+            className={`px-2.5 py-1 rounded text-xs transition-colors ${
+              activeTab === tab
+                ? 'bg-surface-300 text-surface-900'
+                : 'text-surface-600 hover:text-surface-800'
+            }`}
+          >
+            {TAB_LABELS[tab]}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 min-h-0">
+        <RecordViewer activeTab={activeTab} record={record} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/crawl/CrawlRecordList.tsx
+++ b/src/components/crawl/CrawlRecordList.tsx
@@ -1,0 +1,198 @@
+import { useMemo } from 'react'
+import { Loader2 } from 'lucide-react'
+import {
+  CRAWL_PAGE_SIZE_OPTIONS,
+  CRAWL_RECORD_STATUS_LABELS,
+  CRAWL_RECORD_STATUS_OPTIONS,
+} from '../../config/crawl'
+import type { CrawlFilters, CrawlRecordStatus } from '../../types/crawl'
+import { CrawlEmptyState } from './CrawlEmptyState'
+
+interface CrawlRecordListProps {
+  filters: CrawlFilters
+  filteredRecordIndexes: Array<{ index: number }>
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  loading: boolean
+  onNextPage: () => Promise<void> | void
+  onPageSizeChange: (pageSize: number) => Promise<void> | void
+  onPreviousPage: () => Promise<void> | void
+  onSearchChange: (value: string) => void
+  onSelect: (index: number) => void
+  onStatusChange: (status: '' | CrawlRecordStatus) => Promise<void> | void
+  pageIndex: number
+  records: Array<{
+    finalUrl?: string
+    httpStatus?: number
+    index: number
+    status: CrawlRecordStatus
+    title?: string
+    url: string
+  }>
+  resultsError: string | null
+  selectedRecordIndex: number | null
+}
+
+export function CrawlRecordList({
+  filters,
+  filteredRecordIndexes,
+  hasNextPage,
+  hasPreviousPage,
+  loading,
+  onNextPage,
+  onPageSizeChange,
+  onPreviousPage,
+  onSearchChange,
+  onSelect,
+  onStatusChange,
+  pageIndex,
+  records,
+  resultsError,
+  selectedRecordIndex,
+}: CrawlRecordListProps) {
+  const visibleIndexes = useMemo(
+    () => new Set(filteredRecordIndexes.map(({ index }) => index)),
+    [filteredRecordIndexes],
+  )
+
+  return (
+    <div className="h-full flex flex-col glass-panel rounded-xl border border-surface-300 overflow-hidden">
+      <div className="border-b border-surface-300 p-3 bg-surface-100 space-y-3">
+        <div className="grid grid-cols-1 gap-3">
+          <div>
+            <label className="block text-xs text-surface-500 mb-1">Status filter</label>
+            <select
+              value={filters.status}
+              onChange={(event) => void onStatusChange(event.target.value as '' | CrawlRecordStatus)}
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-surface-900 focus:outline-none"
+            >
+              {CRAWL_RECORD_STATUS_OPTIONS.map((option) => (
+                <option key={option.label} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs text-surface-500 mb-1">Page size</label>
+            <select
+              value={filters.pageSize}
+              onChange={(event) => void onPageSizeChange(Number(event.target.value))}
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-surface-900 focus:outline-none"
+            >
+              {CRAWL_PAGE_SIZE_OPTIONS.map((pageSize) => (
+                <option key={pageSize} value={pageSize}>
+                  {pageSize} records
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs text-surface-500 mb-1">
+              Search current page only
+            </label>
+            <input
+              type="text"
+              value={filters.search}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Filter by URL, title, status, or HTTP code"
+              className="w-full px-3 py-2 bg-surface-200 border border-surface-300 rounded-lg text-sm text-surface-900 placeholder:text-surface-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-surface-500">
+          <span>{filteredRecordIndexes.length} visible on this page</span>
+          <span>Page {pageIndex + 1}</span>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-auto">
+        {resultsError ? (
+          <CrawlEmptyState
+            title="Could not load crawl records"
+            description={resultsError}
+          />
+        ) : loading ? (
+          <div className="h-full flex items-center justify-center">
+            <div className="flex items-center gap-2 text-surface-500">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span className="text-sm">Refreshing records…</span>
+            </div>
+          </div>
+        ) : records.length === 0 ? (
+          <CrawlEmptyState
+            title="No records on this page"
+            description="Try a different status filter or refresh the crawl once more results are available."
+          />
+        ) : filteredRecordIndexes.length === 0 ? (
+          <CrawlEmptyState
+            title="No visible matches"
+            description="The current-page search did not match any records. Clear the search box or inspect the raw page records."
+          />
+        ) : (
+          <div className="divide-y divide-surface-300">
+            {records
+              .filter((record) => visibleIndexes.has(record.index))
+              .map((record) => {
+                const selected = selectedRecordIndex === record.index
+                return (
+                  <button
+                    key={`${record.index}-${record.url}`}
+                    type="button"
+                    onClick={() => onSelect(record.index)}
+                    className={`w-full text-left px-3 py-3 transition-colors ${
+                      selected ? 'bg-surface-200' : 'hover:bg-surface-200/60'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm text-surface-900 truncate">
+                          {record.title || record.url}
+                        </p>
+                        <p className="text-xs text-surface-500 truncate">{record.url}</p>
+                        {record.finalUrl && record.finalUrl !== record.url && (
+                          <p className="text-[11px] text-surface-500 truncate">
+                            Final: {record.finalUrl}
+                          </p>
+                        )}
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <span className="inline-flex items-center rounded-full border border-surface-300 px-2 py-0.5 text-[11px] text-surface-700">
+                          {CRAWL_RECORD_STATUS_LABELS[record.status]}
+                        </span>
+                        {record.httpStatus !== undefined && (
+                          <p className="mt-1 text-[11px] text-surface-500">HTTP {record.httpStatus}</p>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                )
+              })}
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-surface-300 px-3 py-2 bg-surface-100 flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => void onPreviousPage()}
+          disabled={!hasPreviousPage || loading}
+          className="px-3 py-1.5 rounded-lg border border-surface-300 text-xs text-surface-700 hover:bg-surface-200 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          onClick={() => void onNextPage()}
+          disabled={!hasNextPage || loading}
+          className="px-3 py-1.5 rounded-lg border border-surface-300 text-xs text-surface-700 hover:bg-surface-200 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/crawl/CrawlWorkspace.tsx
+++ b/src/components/crawl/CrawlWorkspace.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { JsonViewer } from '../viewers/JsonViewer'
+import type {
+  CrawlInspectorTab,
+  CrawlJobSummary as CrawlJobSummaryType,
+  CrawlRecord,
+  CrawlRecordStatus,
+} from '../../types/crawl'
+import { CrawlEmptyState } from './CrawlEmptyState'
+import { CrawlJobSummary } from './CrawlJobSummary'
+import { CrawlRecordInspector } from './CrawlRecordInspector'
+import { CrawlRecordList } from './CrawlRecordList'
+
+interface CrawlWorkspaceProps {
+  availableInspectorTabs: CrawlInspectorTab[]
+  cancelling: boolean
+  cancelCurl: string
+  exporting: boolean
+  filteredRecordIndexes: Array<{ index: number }>
+  filters: { pageSize: number; search: string; status: '' | CrawlRecordStatus }
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  job: CrawlJobSummaryType | null
+  jobError: string | null
+  jobStartedAt: number | null
+  lastRefreshedAt: number | null
+  onCancel: () => Promise<void> | void
+  onExport: () => Promise<void> | void
+  onNextPage: () => Promise<void> | void
+  onPageSizeChange: (pageSize: number) => Promise<void> | void
+  onPreviousPage: () => Promise<void> | void
+  onRefresh: () => Promise<void> | void
+  onSearchChange: (value: string) => void
+  onSelectRecord: (index: number) => void
+  onStatusChange: (status: '' | CrawlRecordStatus) => Promise<void> | void
+  pageIndex: number
+  pollCurl: string
+  polling: boolean
+  records: Array<{
+    finalUrl?: string
+    httpStatus?: number
+    index: number
+    status: CrawlRecordStatus
+    title?: string
+    url: string
+  }>
+  refreshingResults: boolean
+  refreshingSummary: boolean
+  resultsError: string | null
+  selectedInspectorTab: CrawlInspectorTab
+  selectedRecord: CrawlRecord | null
+  selectedRecordIndex: number | null
+  setInspectorTab: (tab: CrawlInspectorTab) => void
+}
+
+export function CrawlWorkspace({
+  availableInspectorTabs,
+  cancelling,
+  cancelCurl,
+  exporting,
+  filteredRecordIndexes,
+  filters,
+  hasNextPage,
+  hasPreviousPage,
+  job,
+  jobError,
+  jobStartedAt,
+  lastRefreshedAt,
+  onCancel,
+  onExport,
+  onNextPage,
+  onPageSizeChange,
+  onPreviousPage,
+  onRefresh,
+  onSearchChange,
+  onSelectRecord,
+  onStatusChange,
+  pageIndex,
+  pollCurl,
+  polling,
+  records,
+  refreshingResults,
+  refreshingSummary,
+  resultsError,
+  selectedInspectorTab,
+  selectedRecord,
+  selectedRecordIndex,
+  setInspectorTab,
+}: CrawlWorkspaceProps) {
+  const [showRawJob, setShowRawJob] = useState(false)
+
+  if (!job) {
+    return (
+      <div className="h-full rounded-xl overflow-hidden shadow-2xl animate-fade-scale">
+        <CrawlEmptyState
+          title="No crawl job yet"
+          description="Configure a starting URL and launch a crawl from the left panel. Results will appear here once the job has been created."
+        />
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="h-full flex flex-col gap-4 rounded-xl overflow-hidden shadow-2xl animate-fade-scale">
+        <CrawlJobSummary
+          cancelling={cancelling}
+          cancelCurl={cancelCurl}
+          exporting={exporting}
+          job={job}
+          jobError={jobError}
+          jobStartedAt={jobStartedAt}
+          lastRefreshedAt={lastRefreshedAt}
+          onCancel={onCancel}
+          onExport={onExport}
+          onRefresh={onRefresh}
+          onViewRawJob={() => setShowRawJob(true)}
+          pollCurl={pollCurl}
+          polling={polling}
+          refreshingSummary={refreshingSummary}
+        />
+
+        <div className="flex-1 min-h-0 grid grid-cols-1 xl:grid-cols-[360px_minmax(0,1fr)] gap-4">
+          <CrawlRecordList
+            filters={filters}
+            filteredRecordIndexes={filteredRecordIndexes}
+            hasNextPage={hasNextPage}
+            hasPreviousPage={hasPreviousPage}
+            loading={refreshingResults}
+            onNextPage={onNextPage}
+            onPageSizeChange={onPageSizeChange}
+            onPreviousPage={onPreviousPage}
+            onSearchChange={onSearchChange}
+            onSelect={onSelectRecord}
+            onStatusChange={onStatusChange}
+            pageIndex={pageIndex}
+            records={records}
+            resultsError={resultsError}
+            selectedRecordIndex={selectedRecordIndex}
+          />
+
+          <div className="min-h-0">
+            {job.status === 'running' && records.length === 0 && !refreshingResults && !resultsError ? (
+              <CrawlEmptyState
+                title="No records loaded yet"
+                description="The crawl is running. Use Refresh to load the current page of partial results without waiting for the job to finish."
+              />
+            ) : (
+              <CrawlRecordInspector
+                activeTab={selectedInspectorTab}
+                availableTabs={availableInspectorTabs}
+                onTabChange={setInspectorTab}
+                record={selectedRecord}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showRawJob && (
+        <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-md flex items-center justify-center px-4">
+          <div className="w-full max-w-4xl max-h-[85vh] glass-panel rounded-2xl overflow-hidden border border-surface-300 shadow-2xl">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-surface-300 bg-surface-100">
+              <p className="text-sm text-surface-900">Raw job JSON</p>
+              <button
+                type="button"
+                onClick={() => setShowRawJob(false)}
+                className="p-2 rounded-lg text-surface-500 hover:text-surface-800 hover:bg-surface-200"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="max-h-[calc(85vh-56px)] overflow-auto">
+              <JsonViewer data={JSON.stringify(job.raw, null, 2)} />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/forms/FieldControl.tsx
+++ b/src/components/forms/FieldControl.tsx
@@ -1,0 +1,78 @@
+import type { FieldConfig } from '../../types/api'
+import { Toggle } from '../Toggle'
+
+function getEffectiveValue(field: FieldConfig, value: string): string {
+  if (value !== undefined && value !== '') return value
+
+  if (field.type === 'boolean' && field.defaultValue !== undefined) {
+    return field.defaultValue ? 'true' : 'false'
+  }
+
+  return value || ''
+}
+
+interface FieldControlProps {
+  field: FieldConfig
+  value: string
+  onChange: (value: string) => void
+  error: boolean
+}
+
+export function FieldControl({
+  field,
+  value,
+  onChange,
+  error,
+}: FieldControlProps) {
+  const effectiveValue = getEffectiveValue(field, value)
+  const border = error
+    ? 'border-red-500/60 focus:border-red-400'
+    : 'border-surface-300 focus:border-accent-500'
+
+  switch (field.type) {
+    case 'textarea':
+    case 'json':
+      return (
+        <textarea
+          value={effectiveValue}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          rows={field.type === 'json' ? 4 : 3}
+          className={`w-full px-3 py-2 bg-surface-200 border ${border} rounded-lg text-sm text-surface-900 placeholder:text-surface-500 focus:outline-none resize-y ${field.type === 'json' ? 'font-mono' : ''}`}
+        />
+      )
+    case 'select':
+      return (
+        <select
+          value={effectiveValue}
+          onChange={(e) => onChange(e.target.value)}
+          className={`w-full px-3 py-2 bg-surface-200 border ${border} rounded-lg text-sm text-surface-900 focus:outline-none`}
+        >
+          <option value="">-- select --</option>
+          {field.options?.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      )
+    case 'boolean':
+      return (
+        <Toggle
+          checked={effectiveValue === 'true'}
+          onChange={(checked) => onChange(checked ? 'true' : 'false')}
+          label={effectiveValue === 'true' ? 'Yes' : 'No'}
+        />
+      )
+    default:
+      return (
+        <input
+          type={field.type === 'number' ? 'number' : 'text'}
+          value={effectiveValue}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          className={`w-full px-3 py-2 bg-surface-200 border ${border} rounded-lg text-sm text-surface-900 placeholder:text-surface-500 focus:outline-none`}
+        />
+      )
+  }
+}

--- a/src/components/forms/FormField.tsx
+++ b/src/components/forms/FormField.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+
+interface FormFieldProps {
+  label: string
+  required?: boolean
+  error?: string
+  hint?: string
+  children: ReactNode
+}
+
+export function FormField({
+  label,
+  required = false,
+  error,
+  hint,
+  children,
+}: FormFieldProps) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-surface-600 mb-1.5">
+        {label}
+        {required && <span className="text-accent-500 ml-1">*</span>}
+      </label>
+      {children}
+      {error ? (
+        <p className="text-xs text-red-400 mt-1.5">{error}</p>
+      ) : hint ? (
+        <p className="text-xs text-surface-500 mt-1.5 leading-relaxed">{hint}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/config/crawl.ts
+++ b/src/config/crawl.ts
@@ -1,0 +1,95 @@
+import type {
+  CrawlCreateFormValues,
+  CrawlFormat,
+  CrawlInspectorTab,
+  CrawlJobStatus,
+  CrawlPurpose,
+  CrawlRecordStatus,
+  CrawlSource,
+} from '../types/crawl'
+
+export const CRAWL_DEFAULTS: CrawlCreateFormValues = {
+  url: '',
+  limit: '25',
+  depth: '2',
+  source: 'all',
+  formats: ['markdown'],
+  render: true,
+  maxAge: '',
+  modifiedSince: '',
+  crawlPurposes: ['search'],
+  includeExternalLinks: false,
+  includeSubdomains: false,
+  includePatterns: '',
+  excludePatterns: '',
+  dismissCookies: false,
+  gotoWaitUntil: '',
+  gotoTimeout: '',
+  waitForSelector: '',
+  setJavaScriptEnabled: true,
+  addScriptTag: '',
+  addStyleTag: '',
+  rejectRequestPattern: '',
+  allowRequestPattern: '',
+  rejectResourceTypes: '',
+  allowResourceTypes: '',
+  jsonPrompt: '',
+  jsonResponseFormat: '',
+  jsonCustomAi: '',
+}
+
+export const CRAWL_PAGE_SIZE_DEFAULT = 50
+
+export const CRAWL_SOURCE_OPTIONS: { label: string; value: CrawlSource; hint: string }[] = [
+  { label: 'All', value: 'all', hint: 'Discover URLs from both sitemaps and links.' },
+  { label: 'Sitemaps', value: 'sitemaps', hint: 'Use sitemap discovery only.' },
+  { label: 'Links', value: 'links', hint: 'Follow page links only.' },
+]
+
+export const CRAWL_FORMAT_OPTIONS: { label: string; value: CrawlFormat; hint: string }[] = [
+  { label: 'Markdown', value: 'markdown', hint: 'Best default for content inspection.' },
+  { label: 'HTML', value: 'html', hint: 'Keep the rendered page source.' },
+  { label: 'JSON', value: 'json', hint: 'AI extraction via Workers AI or custom models.' },
+]
+
+export const CRAWL_PURPOSE_OPTIONS: { label: string; value: CrawlPurpose; hint: string }[] = [
+  { label: 'Search', value: 'search', hint: 'Safest default for site policy compatibility.' },
+  { label: 'AI Input', value: 'ai-input', hint: 'Declare content use for AI systems.' },
+  { label: 'AI Train', value: 'ai-train', hint: 'May be blocked by site Content Signals.' },
+]
+
+export const CRAWL_RECORD_STATUS_OPTIONS: {
+  label: string
+  value: '' | CrawlRecordStatus
+  hint: string
+}[] = [
+  { label: 'All records', value: '', hint: 'No status filter.' },
+  { label: 'Completed', value: 'completed', hint: 'Only successful records.' },
+  { label: 'Errored', value: 'errored', hint: 'Origin errors and blocked pages.' },
+  { label: 'Queued', value: 'queued', hint: 'Discovered but not processed yet.' },
+  { label: 'Disallowed', value: 'disallowed', hint: 'Rejected by robots or policy.' },
+  { label: 'Skipped', value: 'skipped', hint: 'Skipped due to crawl filters.' },
+  { label: 'Cancelled', value: 'cancelled', hint: 'Cancelled before completion.' },
+]
+
+export const CRAWL_PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
+
+export const CRAWL_JOB_STATUS_LABELS: Record<CrawlJobStatus, string> = {
+  running: 'Running',
+  completed: 'Completed',
+  cancelled_due_to_timeout: 'Timed out',
+  cancelled_due_to_limits: 'Cancelled by limits',
+  cancelled_by_user: 'Cancelled by user',
+  errored: 'Errored',
+}
+
+export const CRAWL_RECORD_STATUS_LABELS: Record<CrawlRecordStatus, string> = {
+  queued: 'Queued',
+  completed: 'Completed',
+  disallowed: 'Disallowed',
+  skipped: 'Skipped',
+  errored: 'Errored',
+  cancelled: 'Cancelled',
+}
+
+export const CRAWL_TAB_ORDER: CrawlInspectorTab[] = ['markdown', 'json', 'html', 'raw']

--- a/src/config/endpoints.ts
+++ b/src/config/endpoints.ts
@@ -614,4 +614,14 @@ export const endpoints: EndpointConfig[] = [
       ...sharedFields,
     ],
   },
+  {
+    id: 'crawl',
+    label: 'Crawl',
+    shortDesc: 'Async site crawl',
+    method: 'POST',
+    path: '/crawl',
+    description: 'Launch an async crawl job, then inspect records, filter statuses, paginate results, and export the crawl output.',
+    responseType: 'crawl',
+    fields: [],
+  },
 ]

--- a/src/hooks/useBatchApiRequest.ts
+++ b/src/hooks/useBatchApiRequest.ts
@@ -1,38 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import type { EndpointConfig, Settings, ApiResponse, BatchResponseEntry, RequestState, WorkersPlan } from '../types/api'
+import type { EndpointConfig, Settings, ApiResponse, BatchResponseEntry, RequestState } from '../types/api'
 import { buildFetchOptions } from '../lib/buildRequest'
-
-// Cloudflare Browser Rendering REST API limits (as of Mar 2026):
-// Free Plan: 6 req/min (1 every 10s), 3 concurrent browsers
-// Paid Plan: 600 req/min (10/sec), 30 concurrent browsers
-//
-// IMPORTANT: Rate limits use fixed per-second fill rate, NOT burst allowance.
-// Must spread requests evenly.
-
-const MAX_RETRIES = 3
-
-// Plan-specific rate limit configurations
-// Official limits: https://developers.cloudflare.com/browser-rendering/limits/
-//
-// REST API rate limits (separate from Bindings "new browser instances" limits):
-// Free: 6 req/min (1 every 10s)
-// Paid: 600 req/min (10/sec)
-//
-// Rate limits use FIXED per-second fill rate - must spread evenly, no burst
-const PLAN_LIMITS = {
-  free: {
-    maxConcurrent: 1,           // Free: sequential processing only
-    maxRequestsPerMin: 6,       // 6 req/min
-    minRequestSpacingMs: 10000, // 10 seconds (1 every 10s)
-    initialRetryMs: 15000,      // 15s initial retry delay
-  },
-  paid: {
-    maxConcurrent: 10,          // Reasonable batch size for the playground
-    maxRequestsPerMin: 600,     // 600 req/min (10/sec)
-    minRequestSpacingMs: 100,   // 100ms (10/sec fill rate)
-    initialRetryMs: 5000,       // 5s initial retry delay
-  },
-} as const
+import { MAX_RETRIES, PLAN_LIMITS, waitForRateLimit } from '../lib/rateLimits'
 
 function wait(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -42,55 +11,6 @@ function wait(ms: number, signal?: AbortSignal): Promise<void> {
       reject(new DOMException('Aborted', 'AbortError'))
     }, { once: true })
   })
-}
-
-// Global rate limiter: tracks recent request timestamps across all endpoint tabs
-const globalRequestTimestamps: number[] = []
-const RATE_LIMIT_WINDOW_MS = 60000  // 1 minute window
-
-async function waitForRateLimit(
-  plan: WorkersPlan,
-  signal?: AbortSignal,
-): Promise<void> {
-  const limits = PLAN_LIMITS[plan]
-  const now = Date.now()
-
-  // Clean up timestamps older than 1 minute
-  while (globalRequestTimestamps.length > 0 && globalRequestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
-    globalRequestTimestamps.shift()
-  }
-
-  // Enforce minimum spacing between requests
-  if (globalRequestTimestamps.length > 0) {
-    const lastRequestTime = globalRequestTimestamps[globalRequestTimestamps.length - 1]
-    const timeSinceLastRequest = now - lastRequestTime
-    if (timeSinceLastRequest < limits.minRequestSpacingMs) {
-      const spacingWait = limits.minRequestSpacingMs - timeSinceLastRequest
-      await wait(spacingWait, signal)
-    }
-  }
-
-  // If we've made max requests in the last minute, wait until the oldest one expires
-  const nowAfterSpacing = Date.now()
-  while (globalRequestTimestamps.length > 0 && globalRequestTimestamps[0] < nowAfterSpacing - RATE_LIMIT_WINDOW_MS) {
-    globalRequestTimestamps.shift()
-  }
-
-  if (globalRequestTimestamps.length >= limits.maxRequestsPerMin) {
-    const oldestTimestamp = globalRequestTimestamps[0]
-    const waitTime = (oldestTimestamp + RATE_LIMIT_WINDOW_MS) - nowAfterSpacing
-    if (waitTime > 0) {
-      await wait(waitTime, signal)
-    }
-    // Clean up again after waiting
-    const nowAfterWait = Date.now()
-    while (globalRequestTimestamps.length > 0 && globalRequestTimestamps[0] < nowAfterWait - RATE_LIMIT_WINDOW_MS) {
-      globalRequestTimestamps.shift()
-    }
-  }
-
-  // Record this request
-  globalRequestTimestamps.push(Date.now())
 }
 
 export function useBatchApiRequest() {

--- a/src/hooks/useCrawlJob.ts
+++ b/src/hooks/useCrawlJob.ts
@@ -1,0 +1,609 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { CRAWL_PAGE_SIZE_DEFAULT, CRAWL_TAB_ORDER } from '../config/crawl'
+import {
+  buildCrawlCreateFetchOptions,
+  buildCrawlDeleteUrl,
+  buildCrawlGetUrl,
+  downloadCrawlResultsZip,
+  extractErrorMessage,
+  normalizeCrawlCreateResponse,
+  normalizeCrawlJobSummary,
+  normalizeCrawlResultsPage,
+} from '../lib/crawl'
+import { waitForRateLimit } from '../lib/rateLimits'
+import type { Settings } from '../types/api'
+import type {
+  CrawlCreateFormValues,
+  CrawlCursor,
+  CrawlFilters,
+  CrawlInspectorTab,
+  CrawlJobSummary,
+  CrawlRecord,
+  CrawlRecordStatus,
+  CrawlResultsPage,
+} from '../types/crawl'
+
+const CRAWL_REQUEST_TIMEOUT_MS = 20000
+
+function buildFriendlyError(status: number, message: string | null): string {
+  const normalized = (message || '').toLowerCase()
+
+  if (status === 400 && (normalized.includes('content signal') || normalized.includes('crawlpurpose'))) {
+    return 'This crawl was rejected by the target site Content Signals. Reduce crawl purposes to "search" and try again.'
+  }
+
+  if (status === 429) {
+    return message || 'Cloudflare rate limited this request. Wait a moment and try again.'
+  }
+
+  return message || `Cloudflare returned ${status}.`
+}
+
+function getAvailableTabs(record: CrawlRecord | null): CrawlInspectorTab[] {
+  if (!record) return ['raw']
+
+  return CRAWL_TAB_ORDER.filter((tab) => {
+    switch (tab) {
+      case 'markdown':
+        return Boolean(record.markdown)
+      case 'json':
+        return Boolean(record.json)
+      case 'html':
+        return Boolean(record.html)
+      case 'raw':
+        return true
+    }
+  })
+}
+
+function matchesSearch(record: CrawlRecord, query: string): boolean {
+  if (!query) return true
+
+  const haystack = [
+    record.url,
+    record.finalUrl,
+    record.title,
+    record.status,
+    record.httpStatus?.toString(),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  return haystack.includes(query)
+}
+
+function createPlaceholderJob(id: string): CrawlJobSummary {
+  return {
+    id,
+    status: 'running',
+    browserSecondsUsed: 0,
+    finished: 0,
+    total: 0,
+    skipped: 0,
+    raw: {
+      success: true,
+      result: id,
+    },
+  }
+}
+
+export function useCrawlJob(settings: Settings) {
+  const [job, setJob] = useState<CrawlJobSummary | null>(null)
+  const [resultsPage, setResultsPage] = useState<CrawlResultsPage | null>(null)
+  const [filters, setFilters] = useState<CrawlFilters>({
+    status: '',
+    pageSize: CRAWL_PAGE_SIZE_DEFAULT,
+    search: '',
+  })
+  const [selectedRecordIndex, setSelectedRecordIndex] = useState<number | null>(null)
+  const [selectedInspectorTab, setSelectedInspectorTab] = useState<CrawlInspectorTab>('markdown')
+  const [pageIndex, setPageIndex] = useState(0)
+  const [pageCursors, setPageCursors] = useState<Array<CrawlCursor | undefined>>([undefined])
+  const [creating, setCreating] = useState(false)
+  const [refreshingSummary, setRefreshingSummary] = useState(false)
+  const [refreshingResults, setRefreshingResults] = useState(false)
+  const [polling, setPolling] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const [jobError, setJobError] = useState<string | null>(null)
+  const [resultsError, setResultsError] = useState<string | null>(null)
+  const [jobStartedAt, setJobStartedAt] = useState<number | null>(null)
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null)
+  const [visibilityState, setVisibilityState] = useState<DocumentVisibilityState>(() => document.visibilityState)
+  const deferredSearch = useDeferredValue(filters.search)
+
+  const isMountedRef = useRef(true)
+  const jobRef = useRef<CrawlJobSummary | null>(null)
+  const resultsPageRef = useRef<CrawlResultsPage | null>(null)
+  const filtersRef = useRef(filters)
+  const pageIndexRef = useRef(pageIndex)
+  const pageCursorsRef = useRef(pageCursors)
+  const summaryRequestIdRef = useRef(0)
+  const resultsRequestIdRef = useRef(0)
+
+  useEffect(() => {
+    jobRef.current = job
+  }, [job])
+
+  useEffect(() => {
+    resultsPageRef.current = resultsPage
+  }, [resultsPage])
+
+  useEffect(() => {
+    filtersRef.current = filters
+  }, [filters])
+
+  useEffect(() => {
+    pageIndexRef.current = pageIndex
+  }, [pageIndex])
+
+  useEffect(() => {
+    pageCursorsRef.current = pageCursors
+  }, [pageCursors])
+
+  useEffect(() => {
+    const handleVisibilityChange = () => setVisibilityState(document.visibilityState)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const filteredRecordIndexes = useMemo(() => {
+    const query = deferredSearch.trim().toLowerCase()
+    return (resultsPage?.records || [])
+      .map((record, index) => ({ record, index }))
+      .filter(({ record }) => matchesSearch(record, query))
+  }, [deferredSearch, resultsPage])
+
+  const selectedRecord = useMemo(() => {
+    if (!resultsPage || selectedRecordIndex === null) return null
+    return resultsPage.records[selectedRecordIndex] || null
+  }, [resultsPage, selectedRecordIndex])
+
+  const availableInspectorTabs = useMemo(
+    () => getAvailableTabs(selectedRecord),
+    [selectedRecord],
+  )
+
+  useEffect(() => {
+    if (!filteredRecordIndexes.length) {
+      setSelectedRecordIndex(null)
+      return
+    }
+
+    const visibleIndexes = new Set(filteredRecordIndexes.map(({ index }) => index))
+    if (selectedRecordIndex === null || !visibleIndexes.has(selectedRecordIndex)) {
+      setSelectedRecordIndex(filteredRecordIndexes[0].index)
+    }
+  }, [filteredRecordIndexes, selectedRecordIndex])
+
+  useEffect(() => {
+    if (!availableInspectorTabs.includes(selectedInspectorTab)) {
+      setSelectedInspectorTab(availableInspectorTabs[0] || 'raw')
+    }
+  }, [availableInspectorTabs, selectedInspectorTab])
+
+  const fetchEnvelope = useCallback(async (
+    url: string,
+    init: RequestInit,
+    options: {
+      skipRateLimit?: boolean
+    } = {},
+  ): Promise<unknown> => {
+    if (!options.skipRateLimit) {
+      await waitForRateLimit(settings.plan)
+    }
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), CRAWL_REQUEST_TIMEOUT_MS)
+
+    let response: Response
+    try {
+      response = await fetch(url, {
+        ...init,
+        signal: controller.signal,
+      })
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw new Error('Cloudflare did not respond to the crawl request within 20 seconds.')
+      }
+      throw error
+    } finally {
+      window.clearTimeout(timeout)
+    }
+
+    let payload: unknown = null
+    try {
+      payload = await response.json()
+    } catch {
+      payload = null
+    }
+
+    if (!response.ok) {
+      throw new Error(buildFriendlyError(response.status, extractErrorMessage(payload)))
+    }
+
+    return payload
+  }, [settings.plan])
+
+  const resetResultsState = useCallback(() => {
+    resultsPageRef.current = null
+    pageIndexRef.current = 0
+    pageCursorsRef.current = [undefined]
+    setResultsPage(null)
+    setResultsError(null)
+    setSelectedRecordIndex(null)
+    setSelectedInspectorTab('markdown')
+    setPageIndex(0)
+    setPageCursors([undefined])
+  }, [])
+
+  const fetchResultsPage = useCallback(async (
+    options: {
+      cursor?: CrawlCursor
+      targetPageIndex?: number
+      resetPagination?: boolean
+      skipRateLimit?: boolean
+    } = {},
+  ) => {
+    if (!jobRef.current) return
+
+    const requestId = ++resultsRequestIdRef.current
+    const targetPageIndex = options.resetPagination ? 0 : (options.targetPageIndex ?? pageIndexRef.current)
+    const cursor = options.resetPagination
+      ? undefined
+      : (options.cursor ?? pageCursorsRef.current[targetPageIndex])
+
+    setRefreshingResults(true)
+    setResultsError(null)
+
+    try {
+      const payload = await fetchEnvelope(
+        buildCrawlGetUrl(settings, jobRef.current.id, {
+          cursor,
+          limit: filtersRef.current.pageSize,
+          status: filtersRef.current.status,
+        }),
+        {
+          headers: {
+            Authorization: `Bearer ${settings.apiToken}`,
+          },
+        },
+        {
+          skipRateLimit: options.skipRateLimit,
+        },
+      )
+
+      if (!isMountedRef.current || requestId !== resultsRequestIdRef.current) return
+
+      const page = normalizeCrawlResultsPage(payload)
+      resultsPageRef.current = page
+      setResultsPage(page)
+      setPageIndex(targetPageIndex)
+      setPageCursors((prev) => {
+        if (options.resetPagination) return [undefined]
+        const next = prev.slice(0, Math.max(targetPageIndex + 1, prev.length))
+        if (next[targetPageIndex] === undefined && cursor !== undefined) {
+          next[targetPageIndex] = cursor
+        }
+        return next
+      })
+      setSelectedRecordIndex(page.records.length > 0 ? 0 : null)
+      setLastRefreshedAt(Date.now())
+    } catch (error) {
+      if (!isMountedRef.current || requestId !== resultsRequestIdRef.current) return
+      setResultsError(error instanceof Error ? error.message : 'Failed to fetch crawl results.')
+    } finally {
+      if (isMountedRef.current && requestId === resultsRequestIdRef.current) {
+        setRefreshingResults(false)
+      }
+    }
+  }, [fetchEnvelope, settings])
+
+  const refreshSummary = useCallback(async (
+    options: { origin?: 'manual' | 'poll' | 'create' | 'cancel'; jobId?: string; skipRateLimit?: boolean } = {},
+  ) => {
+    const activeJobId = options.jobId || jobRef.current?.id
+    if (!activeJobId) return
+
+    const requestId = ++summaryRequestIdRef.current
+
+    if (options.origin === 'poll') {
+      setPolling(true)
+    } else {
+      setRefreshingSummary(true)
+    }
+
+    setJobError(null)
+
+    try {
+      const payload = await fetchEnvelope(
+        buildCrawlGetUrl(settings, activeJobId, {
+          limit: 1,
+        }),
+        {
+          headers: {
+            Authorization: `Bearer ${settings.apiToken}`,
+          },
+        },
+        {
+          skipRateLimit: options.skipRateLimit,
+        },
+      )
+
+      if (!isMountedRef.current || requestId !== summaryRequestIdRef.current) return
+
+      const previousStatus = jobRef.current?.status
+      const summary = normalizeCrawlJobSummary(payload)
+      let hasEmbeddedResults = false
+
+      try {
+        const embeddedPage = normalizeCrawlResultsPage(payload)
+        hasEmbeddedResults = embeddedPage.records.length > 0 || embeddedPage.cursor !== undefined
+      } catch {
+        hasEmbeddedResults = false
+      }
+
+      jobRef.current = summary
+      setJob(summary)
+      setLastRefreshedAt(Date.now())
+
+      if (previousStatus === 'running' && summary.status !== 'running') {
+        void fetchResultsPage({
+          resetPagination: true,
+          skipRateLimit: options.skipRateLimit,
+          targetPageIndex: 0,
+        })
+      } else if (
+        summary.status === 'running' &&
+        !resultsPageRef.current &&
+        (
+          summary.finished > 0 ||
+          summary.total > 0 ||
+          summary.browserSecondsUsed > 0 ||
+          hasEmbeddedResults
+        )
+      ) {
+        void fetchResultsPage({
+          resetPagination: true,
+          skipRateLimit: options.skipRateLimit,
+          targetPageIndex: 0,
+        })
+      }
+    } catch (error) {
+      if (!isMountedRef.current || requestId !== summaryRequestIdRef.current) return
+      setJobError(error instanceof Error ? error.message : 'Failed to refresh crawl status.')
+    } finally {
+      const shouldResetLoading = isMountedRef.current && requestId === summaryRequestIdRef.current
+      if (shouldResetLoading) {
+        setPolling(false)
+        setRefreshingSummary(false)
+      }
+    }
+  }, [fetchEnvelope, fetchResultsPage, settings])
+
+  const startJob = useCallback(async (values: CrawlCreateFormValues) => {
+    setCreating(true)
+    setJobError(null)
+    setResultsError(null)
+    resetResultsState()
+    filtersRef.current = {
+      pageSize: CRAWL_PAGE_SIZE_DEFAULT,
+      search: '',
+      status: '',
+    }
+    setFilters({
+      pageSize: CRAWL_PAGE_SIZE_DEFAULT,
+      search: '',
+      status: '',
+    })
+
+    try {
+      const { url, options } = buildCrawlCreateFetchOptions(settings, values)
+      const payload = await fetchEnvelope(url, options)
+      const jobId = normalizeCrawlCreateResponse(payload)
+      const placeholder = createPlaceholderJob(jobId)
+      setJobStartedAt(Date.now())
+      jobRef.current = placeholder
+      setJob(placeholder)
+      await refreshSummary({ jobId, origin: 'create', skipRateLimit: true })
+    } catch (error) {
+      setJobStartedAt(null)
+      jobRef.current = null
+      setJob(null)
+      setJobError(error instanceof Error ? error.message : 'Failed to start crawl.')
+    } finally {
+      if (isMountedRef.current) {
+        setCreating(false)
+      }
+    }
+  }, [fetchEnvelope, refreshSummary, resetResultsState, settings])
+
+  const refreshAll = useCallback(async () => {
+    await refreshSummary({ origin: 'manual', skipRateLimit: true })
+    await fetchResultsPage({ skipRateLimit: true, targetPageIndex: pageIndexRef.current })
+  }, [fetchResultsPage, refreshSummary])
+
+  const cancelJob = useCallback(async () => {
+    if (!jobRef.current) return
+
+    setCancelling(true)
+    setJobError(null)
+
+    try {
+      await fetchEnvelope(
+        buildCrawlDeleteUrl(settings, jobRef.current.id),
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${settings.apiToken}`,
+          },
+        },
+      )
+
+      await refreshSummary({ origin: 'cancel' })
+      await fetchResultsPage({ targetPageIndex: pageIndexRef.current })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to cancel crawl.'
+      setJobError(message)
+
+      if (message.toLowerCase().includes('already completed') || message.toLowerCase().includes('cannot be cancelled')) {
+        await refreshSummary({ origin: 'manual', skipRateLimit: true })
+        void fetchResultsPage({ skipRateLimit: true, targetPageIndex: pageIndexRef.current })
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setCancelling(false)
+      }
+    }
+  }, [fetchEnvelope, fetchResultsPage, refreshSummary, settings])
+
+  const goToNextPage = useCallback(async () => {
+    if (!resultsPage?.cursor) return
+
+    const nextIndex = pageIndexRef.current + 1
+    setPageCursors((prev) => {
+      const next = prev.slice()
+      next[nextIndex] = resultsPage.cursor
+      return next
+    })
+
+    await fetchResultsPage({
+      cursor: resultsPage.cursor,
+      targetPageIndex: nextIndex,
+    })
+  }, [fetchResultsPage, resultsPage])
+
+  const goToPreviousPage = useCallback(async () => {
+    if (pageIndexRef.current === 0) return
+
+    const nextIndex = pageIndexRef.current - 1
+    await fetchResultsPage({
+      cursor: pageCursorsRef.current[nextIndex],
+      targetPageIndex: nextIndex,
+    })
+  }, [fetchResultsPage])
+
+  const setStatusFilter = useCallback(async (status: '' | CrawlRecordStatus) => {
+    filtersRef.current = { ...filtersRef.current, status }
+    setFilters(filtersRef.current)
+    await fetchResultsPage({
+      resetPagination: true,
+      targetPageIndex: 0,
+    })
+  }, [fetchResultsPage])
+
+  const setPageSize = useCallback(async (pageSize: number) => {
+    filtersRef.current = { ...filtersRef.current, pageSize }
+    setFilters(filtersRef.current)
+    await fetchResultsPage({
+      resetPagination: true,
+      targetPageIndex: 0,
+    })
+  }, [fetchResultsPage])
+
+  const setSearch = useCallback((search: string) => {
+    filtersRef.current = { ...filtersRef.current, search }
+    setFilters(filtersRef.current)
+  }, [])
+
+  const exportFilteredResults = useCallback(async () => {
+    if (!jobRef.current || jobRef.current.status === 'running') return
+
+    setExporting(true)
+    setJobError(null)
+
+    try {
+      const collected: CrawlRecord[] = []
+      let cursor: CrawlCursor | undefined
+
+      while (true) {
+        const payload = await fetchEnvelope(
+          buildCrawlGetUrl(settings, jobRef.current.id, {
+            cursor,
+            limit: filtersRef.current.pageSize,
+            status: filtersRef.current.status,
+          }),
+          {
+            headers: {
+              Authorization: `Bearer ${settings.apiToken}`,
+            },
+          },
+        )
+
+        const page = normalizeCrawlResultsPage(payload)
+        collected.push(...page.records)
+
+        if (page.cursor === undefined) break
+        cursor = page.cursor
+      }
+
+      await downloadCrawlResultsZip(jobRef.current, collected)
+    } catch (error) {
+      setJobError(error instanceof Error ? error.message : 'Failed to export crawl results.')
+    } finally {
+      if (isMountedRef.current) {
+        setExporting(false)
+      }
+    }
+  }, [fetchEnvelope, settings])
+
+  const selectRecord = useCallback((index: number) => {
+    setSelectedRecordIndex(index)
+  }, [])
+
+  useEffect(() => {
+    if (!job || job.status !== 'running') return
+
+    const delay = settings.plan === 'free'
+      ? (visibilityState === 'hidden' ? 30000 : 15000)
+      : (visibilityState === 'hidden' ? 15000 : 5000)
+
+    const timer = window.setTimeout(() => {
+      void refreshSummary({ origin: 'poll' })
+    }, delay)
+
+    return () => window.clearTimeout(timer)
+  }, [job, refreshSummary, settings.plan, visibilityState, lastRefreshedAt])
+
+  return {
+    availableInspectorTabs,
+    cancelling,
+    creating,
+    exportFilteredResults,
+    exporting,
+    filteredRecordIndexes,
+    filters,
+    goToNextPage,
+    goToPreviousPage,
+    hasNextPage: Boolean(resultsPage?.cursor),
+    hasPreviousPage: pageIndex > 0,
+    job,
+    jobError,
+    jobStartedAt,
+    lastRefreshedAt,
+    pageIndex,
+    polling,
+    refreshAll,
+    refreshingResults,
+    refreshingSummary,
+    resultsError,
+    resultsPage,
+    selectedInspectorTab,
+    selectedRecord,
+    selectedRecordIndex,
+    selectRecord,
+    setInspectorTab: setSelectedInspectorTab,
+    setPageSize,
+    setSearch,
+    setStatusFilter,
+    startJob,
+    cancelJob,
+  }
+}

--- a/src/lib/buildRequest.ts
+++ b/src/lib/buildRequest.ts
@@ -9,7 +9,7 @@ import type { EndpointConfig, Settings } from '../types/api'
 // Covers: OneTrust, Cookiebot, Quantcast, Didomi, TrustArc, Usercentrics, Klaro,
 // Osano, Termly, CookieYes, Complianz, Iubenda, Axeptio, Sourcepoint, CookieFirst,
 // Borlabs, CIVIC, consentmanager.net, and generic cookie/consent/gdpr patterns.
-const CMP_BLOCK_PATTERNS: string[] = [
+export const CMP_BLOCK_PATTERNS: string[] = [
   // OneTrust
   'cdn\\.cookielaw\\.org',
   'optanon\\.blob\\.core',
@@ -68,7 +68,7 @@ const CMP_BLOCK_PATTERNS: string[] = [
 
 // Fallback cleanup script for banners that still appear (inline/custom implementations).
 // Approach based on reject_all_cookies, DuckDuckGo autoconsent, and screenshotone.com.
-const DISMISS_COOKIES_SCRIPT = `
+export const DISMISS_COOKIES_SCRIPT = `
 (function() {
   function isVisible(el) {
     if (!el || el.hidden || el.style.display === 'none') return false;

--- a/src/lib/crawl.ts
+++ b/src/lib/crawl.ts
@@ -1,0 +1,465 @@
+import JSZip from 'jszip'
+import { CMP_BLOCK_PATTERNS, DISMISS_COOKIES_SCRIPT } from './buildRequest'
+import type { Settings, WorkersPlan } from '../types/api'
+import type {
+  CrawlCreateFormValues,
+  CrawlCursor,
+  CrawlJobSummary,
+  CrawlRecord,
+  CrawlRecordStatus,
+  CrawlResultsPage,
+} from '../types/crawl'
+
+type JsonExpectation = 'array' | 'object' | 'any'
+
+export type CrawlFieldErrors = Partial<Record<keyof CrawlCreateFormValues, string>>
+
+function parseJsonField(
+  raw: string,
+  expectation: JsonExpectation,
+): unknown {
+  const parsed = JSON.parse(raw)
+
+  if (expectation === 'array' && !Array.isArray(parsed)) {
+    throw new Error('Must be a JSON array.')
+  }
+
+  if (expectation === 'object' && (!parsed || Array.isArray(parsed) || typeof parsed !== 'object')) {
+    throw new Error('Must be a JSON object.')
+  }
+
+  return parsed
+}
+
+export function validateCrawlFormValues(
+  values: CrawlCreateFormValues,
+  plan: WorkersPlan,
+): CrawlFieldErrors {
+  const errors: CrawlFieldErrors = {}
+  const urlTokens = values.url.trim().split(/\s+/).filter(Boolean)
+
+  if (urlTokens.length === 0) {
+    errors.url = 'A starting URL is required.'
+  } else if (urlTokens.length > 1) {
+    errors.url = 'Enter exactly one starting URL.'
+  }
+
+  if (values.formats.length === 0) {
+    errors.formats = 'Select at least one output format.'
+  }
+
+  if (plan === 'free' && values.limit.trim()) {
+    const limit = Number(values.limit)
+    if (!Number.isFinite(limit) || limit > 100) {
+      errors.limit = 'Workers Free plan is limited to 100 pages per crawl.'
+    }
+  }
+
+  if (values.formats.includes('json') && !values.jsonPrompt.trim() && !values.jsonResponseFormat.trim()) {
+    errors.jsonPrompt = 'JSON format requires a prompt or response schema.'
+    errors.jsonResponseFormat = 'JSON format requires a prompt or response schema.'
+  }
+
+  const jsonFields: Array<[keyof CrawlCreateFormValues, JsonExpectation]> = [
+    ['includePatterns', 'array'],
+    ['excludePatterns', 'array'],
+    ['jsonResponseFormat', 'object'],
+    ['jsonCustomAi', 'array'],
+    ['addScriptTag', 'array'],
+    ['addStyleTag', 'array'],
+    ['rejectRequestPattern', 'array'],
+    ['allowRequestPattern', 'array'],
+    ['rejectResourceTypes', 'array'],
+    ['allowResourceTypes', 'array'],
+  ]
+
+  for (const [field, expectation] of jsonFields) {
+    const raw = values[field]
+    if (typeof raw !== 'string' || !raw.trim()) continue
+
+    try {
+      parseJsonField(raw, expectation)
+    } catch (error) {
+      errors[field] = error instanceof Error ? error.message : 'Invalid JSON.'
+    }
+  }
+
+  return errors
+}
+
+function maybeSetNumber(
+  target: Record<string, unknown>,
+  key: string,
+  raw: string,
+) {
+  if (!raw.trim()) return
+  const value = Number(raw)
+  if (!Number.isNaN(value)) {
+    target[key] = value
+  }
+}
+
+function maybeSetJson(
+  target: Record<string, unknown>,
+  key: string,
+  raw: string,
+  expectation: JsonExpectation,
+) {
+  if (!raw.trim()) return
+  target[key] = parseJsonField(raw, expectation)
+}
+
+export function buildCrawlCreateBody(
+  values: CrawlCreateFormValues,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    url: values.url.trim(),
+    source: values.source,
+    render: values.render,
+    formats: values.formats,
+    crawlPurposes: values.crawlPurposes,
+  }
+
+  maybeSetNumber(body, 'limit', values.limit)
+  maybeSetNumber(body, 'depth', values.depth)
+  maybeSetNumber(body, 'maxAge', values.maxAge)
+  maybeSetNumber(body, 'modifiedSince', values.modifiedSince)
+
+  const options: Record<string, unknown> = {
+    includeExternalLinks: values.includeExternalLinks,
+    includeSubdomains: values.includeSubdomains,
+  }
+
+  maybeSetJson(options, 'includePatterns', values.includePatterns, 'array')
+  maybeSetJson(options, 'excludePatterns', values.excludePatterns, 'array')
+
+  if (Object.keys(options).length > 0) {
+    body.options = options
+  }
+
+  if (values.formats.includes('json')) {
+    const jsonOptions: Record<string, unknown> = {}
+
+    if (values.jsonPrompt.trim()) {
+      jsonOptions.prompt = values.jsonPrompt.trim()
+    }
+
+    maybeSetJson(jsonOptions, 'response_format', values.jsonResponseFormat, 'object')
+    maybeSetJson(jsonOptions, 'custom_ai', values.jsonCustomAi, 'array')
+
+    if (Object.keys(jsonOptions).length > 0) {
+      body.jsonOptions = jsonOptions
+    }
+  }
+
+  if (values.render) {
+    const gotoOptions: Record<string, unknown> = {}
+    if (values.gotoWaitUntil) {
+      gotoOptions.waitUntil = values.gotoWaitUntil
+    }
+    maybeSetNumber(gotoOptions, 'timeout', values.gotoTimeout)
+    if (Object.keys(gotoOptions).length > 0) {
+      body.gotoOptions = gotoOptions
+    }
+
+    if (values.waitForSelector.trim()) {
+      body.waitForSelector = { selector: values.waitForSelector.trim() }
+    }
+
+    if (!values.setJavaScriptEnabled) {
+      body.setJavaScriptEnabled = false
+    }
+
+    maybeSetJson(body, 'addScriptTag', values.addScriptTag, 'array')
+    maybeSetJson(body, 'addStyleTag', values.addStyleTag, 'array')
+    maybeSetJson(body, 'rejectRequestPattern', values.rejectRequestPattern, 'array')
+    maybeSetJson(body, 'allowRequestPattern', values.allowRequestPattern, 'array')
+    maybeSetJson(body, 'rejectResourceTypes', values.rejectResourceTypes, 'array')
+    maybeSetJson(body, 'allowResourceTypes', values.allowResourceTypes, 'array')
+
+    if (values.dismissCookies) {
+      const currentScripts = Array.isArray(body.addScriptTag) ? body.addScriptTag as unknown[] : []
+      const currentRejectPatterns = Array.isArray(body.rejectRequestPattern)
+        ? body.rejectRequestPattern as string[]
+        : []
+
+      body.addScriptTag = [{ content: DISMISS_COOKIES_SCRIPT }, ...currentScripts]
+      body.rejectRequestPattern = [...CMP_BLOCK_PATTERNS, ...currentRejectPatterns]
+    }
+  }
+
+  return body
+}
+
+function buildAuthHeaders(settings: Settings) {
+  return {
+    Authorization: `Bearer ${settings.apiToken}`,
+    'Content-Type': 'application/json',
+  }
+}
+
+export function buildCrawlCreateFetchOptions(
+  settings: Settings,
+  values: CrawlCreateFormValues,
+) {
+  return {
+    url: `/api/cf/client/v4/accounts/${settings.accountId}/browser-rendering/crawl`,
+    options: {
+      method: 'POST',
+      headers: buildAuthHeaders(settings),
+      body: JSON.stringify(buildCrawlCreateBody(values)),
+    },
+  }
+}
+
+export function buildCrawlGetUrl(
+  settings: Settings,
+  jobId: string,
+  params: { limit?: number; cursor?: CrawlCursor; status?: '' | CrawlRecordStatus } = {},
+) {
+  const query = new URLSearchParams()
+
+  if (params.limit !== undefined) query.set('limit', String(params.limit))
+  if (params.cursor !== undefined) query.set('cursor', String(params.cursor))
+  if (params.status) query.set('status', params.status)
+
+  const suffix = query.toString() ? `?${query.toString()}` : ''
+  return `/api/cf/client/v4/accounts/${settings.accountId}/browser-rendering/crawl/${jobId}${suffix}`
+}
+
+export function buildCrawlDeleteUrl(
+  settings: Settings,
+  jobId: string,
+) {
+  return `/api/cf/client/v4/accounts/${settings.accountId}/browser-rendering/crawl/${jobId}`
+}
+
+function buildCurlCommand(
+  method: 'GET' | 'POST' | 'DELETE',
+  url: string,
+  token: string,
+  body?: Record<string, unknown>,
+) {
+  const parts = [
+    `curl -X ${method}`,
+    `  "${url}"`,
+    `  -H "Authorization: Bearer ${token}"`,
+  ]
+
+  if (body) {
+    parts.push('  -H "Content-Type: application/json"')
+    parts.push(`  -d '${JSON.stringify(body, null, 2)}'`)
+  }
+
+  return parts.join(' \\\n')
+}
+
+export function buildCrawlCreateCurlCommand(
+  settings: Settings,
+  values: CrawlCreateFormValues,
+  maskToken = true,
+) {
+  const token = maskToken ? '<API_TOKEN>' : (settings.apiToken || '<API_TOKEN>')
+  const url = `https://api.cloudflare.com/client/v4/accounts/${settings.accountId || '<ACCOUNT_ID>'}/browser-rendering/crawl`
+  return buildCurlCommand('POST', url, token, buildCrawlCreateBody(values))
+}
+
+export function buildCrawlGetCurlCommand(
+  settings: Settings,
+  jobId: string,
+  params: { limit?: number; cursor?: CrawlCursor; status?: '' | CrawlRecordStatus } = {},
+  maskToken = true,
+) {
+  const token = maskToken ? '<API_TOKEN>' : (settings.apiToken || '<API_TOKEN>')
+  const path = buildCrawlGetUrl(
+    { ...settings, accountId: settings.accountId || '<ACCOUNT_ID>' },
+    jobId,
+    params,
+  )
+  return buildCurlCommand('GET', `https://api.cloudflare.com${path.replace(/^\/api\/cf/, '')}`, token)
+}
+
+export function buildCrawlDeleteCurlCommand(
+  settings: Settings,
+  jobId: string,
+  maskToken = true,
+) {
+  const token = maskToken ? '<API_TOKEN>' : (settings.apiToken || '<API_TOKEN>')
+  const path = buildCrawlDeleteUrl(
+    { ...settings, accountId: settings.accountId || '<ACCOUNT_ID>' },
+    jobId,
+  )
+  return buildCurlCommand('DELETE', `https://api.cloudflare.com${path.replace(/^\/api\/cf/, '')}`, token)
+}
+
+type CrawlEnvelopeResult = Record<string, unknown> | string
+
+interface CrawlEnvelope {
+  result: CrawlEnvelopeResult
+  success?: boolean
+  errors?: Array<{ code?: number; message?: string }>
+}
+
+function normalizeCursor(value: unknown): CrawlCursor | undefined {
+  if (typeof value === 'string' || typeof value === 'number') return value
+  return undefined
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+function normalizeRecord(raw: Record<string, unknown>): CrawlRecord {
+  const metadataRaw = (raw.metadata && typeof raw.metadata === 'object' && !Array.isArray(raw.metadata))
+    ? raw.metadata as Record<string, unknown>
+    : {}
+
+  const jsonRaw = raw.json
+  return {
+    url: typeof raw.url === 'string' ? raw.url : '',
+    status: typeof raw.status === 'string' ? raw.status as CrawlRecordStatus : 'queued',
+    httpStatus: normalizeNumber(metadataRaw.status),
+    finalUrl: typeof metadataRaw.url === 'string' ? metadataRaw.url : undefined,
+    title: typeof metadataRaw.title === 'string' ? metadataRaw.title : undefined,
+    html: typeof raw.html === 'string' ? raw.html : undefined,
+    markdown: typeof raw.markdown === 'string' ? raw.markdown : undefined,
+    json: jsonRaw && typeof jsonRaw === 'object' && !Array.isArray(jsonRaw)
+      ? jsonRaw as Record<string, unknown>
+      : undefined,
+    metadata: {
+      status: normalizeNumber(metadataRaw.status) ?? 0,
+      url: typeof metadataRaw.url === 'string' ? metadataRaw.url : '',
+      title: typeof metadataRaw.title === 'string' ? metadataRaw.title : undefined,
+    },
+    raw,
+  }
+}
+
+export function extractErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const envelope = payload as CrawlEnvelope
+  if (!Array.isArray(envelope.errors) || envelope.errors.length === 0) return null
+  return envelope.errors
+    .map((error) => error.message)
+    .filter((message): message is string => Boolean(message))
+    .join(' ')
+}
+
+export function normalizeCrawlCreateResponse(payload: unknown): string {
+  const envelope = payload as CrawlEnvelope
+  if (typeof envelope.result !== 'string' || !envelope.result) {
+    throw new Error('Cloudflare did not return a crawl job ID.')
+  }
+  return envelope.result
+}
+
+export function normalizeCrawlJobSummary(payload: unknown): CrawlJobSummary {
+  const envelope = payload as CrawlEnvelope
+  if (!envelope.result || typeof envelope.result !== 'object' || Array.isArray(envelope.result)) {
+    throw new Error('Cloudflare did not return crawl job details.')
+  }
+
+  const result = envelope.result as Record<string, unknown>
+  return {
+    id: typeof result.id === 'string' ? result.id : '',
+    status: typeof result.status === 'string' ? result.status as CrawlJobSummary['status'] : 'errored',
+    browserSecondsUsed: normalizeNumber(result.browserSecondsUsed) ?? 0,
+    finished: normalizeNumber(result.finished) ?? 0,
+    total: normalizeNumber(result.total) ?? 0,
+    skipped: normalizeNumber(result.skipped) ?? 0,
+    cursor: normalizeCursor(result.cursor),
+    raw: envelope as unknown as Record<string, unknown>,
+  }
+}
+
+export function normalizeCrawlResultsPage(payload: unknown): CrawlResultsPage {
+  const envelope = payload as CrawlEnvelope
+  if (!envelope.result || typeof envelope.result !== 'object' || Array.isArray(envelope.result)) {
+    throw new Error('Cloudflare did not return crawl records.')
+  }
+
+  const result = envelope.result as Record<string, unknown>
+  const records = Array.isArray(result.records)
+    ? result.records
+        .filter((record): record is Record<string, unknown> => Boolean(record) && typeof record === 'object' && !Array.isArray(record))
+        .map(normalizeRecord)
+    : []
+
+  return {
+    records,
+    cursor: normalizeCursor(result.cursor),
+    raw: envelope as unknown as Record<string, unknown>,
+  }
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120) || 'record'
+}
+
+function buildRecordSlug(record: CrawlRecord, index: number) {
+  return `${String(index + 1).padStart(4, '0')}-${slugify(record.finalUrl || record.url)}`
+}
+
+function triggerBlobDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+export async function downloadCrawlResultsZip(
+  job: CrawlJobSummary,
+  records: CrawlRecord[],
+) {
+  const zip = new JSZip()
+
+  zip.file(
+    'job.json',
+    JSON.stringify(
+      {
+        summary: {
+          id: job.id,
+          status: job.status,
+          browserSecondsUsed: job.browserSecondsUsed,
+          finished: job.finished,
+          total: job.total,
+          skipped: job.skipped,
+          cursor: job.cursor ?? null,
+        },
+        rawEnvelope: job.raw,
+      },
+      null,
+      2,
+    ),
+  )
+  zip.file('records.jsonl', records.map((record) => JSON.stringify(record.raw)).join('\n'))
+
+  records.forEach((record, index) => {
+    const slug = buildRecordSlug(record, index)
+    if (record.markdown) {
+      zip.file(`markdown/${slug}.md`, record.markdown)
+    }
+    if (record.html) {
+      const folder = record.status === 'errored' ? 'errors' : 'html'
+      zip.file(`${folder}/${slug}.html`, record.html)
+    }
+    if (record.json) {
+      zip.file(`json/${slug}.json`, JSON.stringify(record.json, null, 2))
+    }
+  })
+
+  const blob = await zip.generateAsync({ type: 'blob' })
+  triggerBlobDownload(blob, `crawl-${job.id}.zip`)
+}

--- a/src/lib/rateLimits.ts
+++ b/src/lib/rateLimits.ts
@@ -1,0 +1,71 @@
+import type { WorkersPlan } from '../types/api'
+
+export const MAX_RETRIES = 3
+
+export const PLAN_LIMITS = {
+  free: {
+    maxConcurrent: 1,
+    maxRequestsPerMin: 6,
+    minRequestSpacingMs: 10000,
+    initialRetryMs: 15000,
+  },
+  paid: {
+    maxConcurrent: 10,
+    maxRequestsPerMin: 600,
+    minRequestSpacingMs: 100,
+    initialRetryMs: 5000,
+  },
+} as const
+
+function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }, { once: true })
+  })
+}
+
+const globalRequestTimestamps: number[] = []
+const RATE_LIMIT_WINDOW_MS = 60000
+
+export async function waitForRateLimit(
+  plan: WorkersPlan,
+  signal?: AbortSignal,
+): Promise<void> {
+  const limits = PLAN_LIMITS[plan]
+  const now = Date.now()
+
+  while (globalRequestTimestamps.length > 0 && globalRequestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
+    globalRequestTimestamps.shift()
+  }
+
+  if (globalRequestTimestamps.length > 0) {
+    const lastRequestTime = globalRequestTimestamps[globalRequestTimestamps.length - 1]
+    const timeSinceLastRequest = now - lastRequestTime
+    if (timeSinceLastRequest < limits.minRequestSpacingMs) {
+      await wait(limits.minRequestSpacingMs - timeSinceLastRequest, signal)
+    }
+  }
+
+  const nowAfterSpacing = Date.now()
+  while (globalRequestTimestamps.length > 0 && globalRequestTimestamps[0] < nowAfterSpacing - RATE_LIMIT_WINDOW_MS) {
+    globalRequestTimestamps.shift()
+  }
+
+  if (globalRequestTimestamps.length >= limits.maxRequestsPerMin) {
+    const oldestTimestamp = globalRequestTimestamps[0]
+    const waitTime = (oldestTimestamp + RATE_LIMIT_WINDOW_MS) - nowAfterSpacing
+    if (waitTime > 0) {
+      await wait(waitTime, signal)
+    }
+
+    const nowAfterWait = Date.now()
+    while (globalRequestTimestamps.length > 0 && globalRequestTimestamps[0] < nowAfterWait - RATE_LIMIT_WINDOW_MS) {
+      globalRequestTimestamps.shift()
+    }
+  }
+
+  globalRequestTimestamps.push(Date.now())
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7,8 +7,9 @@ export type EndpointId =
   | 'snapshot'
   | 'scrape'
   | 'links'
+  | 'crawl'
 
-export type ResponseType = 'html' | 'image' | 'pdf' | 'json' | 'markdown' | 'snapshot'
+export type ResponseType = 'html' | 'image' | 'pdf' | 'json' | 'markdown' | 'snapshot' | 'crawl'
 
 export type FieldType = 'text' | 'number' | 'boolean' | 'select' | 'textarea' | 'json'
 

--- a/src/types/crawl.ts
+++ b/src/types/crawl.ts
@@ -1,0 +1,94 @@
+export type CrawlJobStatus =
+  | 'running'
+  | 'completed'
+  | 'cancelled_due_to_timeout'
+  | 'cancelled_due_to_limits'
+  | 'cancelled_by_user'
+  | 'errored'
+
+export type CrawlRecordStatus =
+  | 'queued'
+  | 'completed'
+  | 'disallowed'
+  | 'skipped'
+  | 'errored'
+  | 'cancelled'
+
+export type CrawlCursor = string | number
+
+export type CrawlFormat = 'html' | 'markdown' | 'json'
+export type CrawlSource = 'all' | 'sitemaps' | 'links'
+export type CrawlPurpose = 'search' | 'ai-input' | 'ai-train'
+export type CrawlInspectorTab = 'markdown' | 'html' | 'json' | 'raw'
+
+export interface CrawlCreateFormValues {
+  url: string
+  limit: string
+  depth: string
+  source: CrawlSource
+  formats: CrawlFormat[]
+  render: boolean
+  maxAge: string
+  modifiedSince: string
+  crawlPurposes: CrawlPurpose[]
+  includeExternalLinks: boolean
+  includeSubdomains: boolean
+  includePatterns: string
+  excludePatterns: string
+  dismissCookies: boolean
+  gotoWaitUntil: '' | 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'
+  gotoTimeout: string
+  waitForSelector: string
+  setJavaScriptEnabled: boolean
+  addScriptTag: string
+  addStyleTag: string
+  rejectRequestPattern: string
+  allowRequestPattern: string
+  rejectResourceTypes: string
+  allowResourceTypes: string
+  jsonPrompt: string
+  jsonResponseFormat: string
+  jsonCustomAi: string
+}
+
+export interface CrawlRecordMetadata {
+  status: number
+  url: string
+  title?: string
+}
+
+export interface CrawlRecord {
+  url: string
+  status: CrawlRecordStatus
+  httpStatus?: number
+  finalUrl?: string
+  title?: string
+  html?: string
+  json?: Record<string, unknown>
+  markdown?: string
+  metadata: CrawlRecordMetadata
+  raw: Record<string, unknown>
+}
+
+export interface CrawlJobSummary {
+  id: string
+  status: CrawlJobStatus
+  browserSecondsUsed: number
+  finished: number
+  total: number
+  skipped: number
+  cursor?: CrawlCursor
+  raw: Record<string, unknown>
+}
+
+export interface CrawlResultsPage {
+  records: CrawlRecord[]
+  cursor?: CrawlCursor
+  raw: Record<string, unknown>
+}
+
+export interface CrawlFilters {
+  status: '' | CrawlRecordStatus
+  pageSize: number
+  search: string
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -89,7 +89,7 @@ async function handleApiProxy(request: Request, url: URL): Promise<Response> {
   // Return response with CORS headers
   const proxyResponse = new Response(response.body, response)
   proxyResponse.headers.set('Access-Control-Allow-Origin', '*')
-  proxyResponse.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  proxyResponse.headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   proxyResponse.headers.set('Access-Control-Allow-Headers', '*')
 
   return proxyResponse


### PR DESCRIPTION
## Summary
- add a dedicated first-class `/crawl` workflow with create, poll, cancel, inspect, pagination, and export support
- fix the local-dev stale crawl state bug caused by the crawl hook mount guard under React Strict Mode and add an elapsed timer to the crawl summary
- reduce local UI overhead by deferring current-page search work, removing an extra summary state update, and avoiding quadratic visible-record filtering

## Testing
- npm run build
- npm run lint
- live local verification with agent-browser against http://localhost:5173 using the real crawl flow and Cloudflare API responses